### PR TITLE
Update command to apply pod-security policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the policiies based on your requirements.
 
 ```console
 cd kyverno-policies
-kubectl apply -f pod-security
+kubectl apply -f pod-security --recursive
 kubectl apply -f multitenancy
 kubectl apply -f best-practices
 ```


### PR DESCRIPTION
The `pod-security` policies are in nested directories. Use the `--recusrsive` flag to apply all policies.

Without the flag, we get this error -
```
> kubectl apply -f pod-security                                                                                  
error: error reading [pod-security]: recognized file extensions are [.json .yaml .yml]
```