### PR TITLE
Update eksConfig to eksCluster

### DIFF
--- a/eks-best-practices/check-cluster-tags.yaml
+++ b/eks-best-practices/check-cluster-tags.yaml
@@ -23,6 +23,6 @@ spec:
         message: "The `department` tag on the cluster is required. The field status.eksConfig.tags.department must exist with some value."
         pattern:
           status:
-            eksConfig:
+            eksCluster:
               tags:
                 department: "?*"


### PR DESCRIPTION
The right key in aws adapter's status field is eksCluster. Changing the key to eksCluster in the policy.

Refer https://github.com/nirmata/kyverno-aws-adapter/blob/bfba1aa6a2b2562d7e7fc4132dd0983532fe0b6f/api/v1alpha1/awsadapterconfig_types.go#L188

Fixes #8 

