### PR TITLE
Disable chart linting temporarily

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -29,5 +29,5 @@ jobs:
         uses: helm/chart-testing-action@v2
       - name: Check docs are up to date
         run: make verify-helm-docs
-      - name: Run chart-testing (lint)
-        run: ct lint --target-branch=main --all --check-version-increment=false
+#      - name: Run chart-testing (lint)
+#        run: ct lint --target-branch=main --all --check-version-increment=false


### PR DESCRIPTION
Until we have charts in the repo, ct lint will fail because there are no charts present that it can lint against. Disabling until we add charts to this repo