### PR TITLE
Revert kyverno annotation

### DIFF
--- a/best-practices/add_network_policy/add_network_policy.yaml
+++ b/best-practices/add_network_policy/add_network_policy.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: add-networkpolicy
   annotations:
-    policies.nirmata.io/title: Add Network Policy
-    policies.nirmata.io/category: Multi-Tenancy, EKS Best Practices
-    policies.nirmata.io/subject: NetworkPolicy
+    policies.kyverno.io/title: Add Network Policy
+    policies.kyverno.io/category: Multi-Tenancy, EKS Best Practices
+    policies.kyverno.io/subject: NetworkPolicy
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       By default, Kubernetes allows communications across all Pods within a cluster.
       The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict
       communications. A default NetworkPolicy should be configured for each Namespace to

--- a/best-practices/add_networkpolicy_dns/add-networkpolicy-dns.yaml
+++ b/best-practices/add_networkpolicy_dns/add-networkpolicy-dns.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: add-networkpolicy-dns
   annotations:
-    policies.nirmata.io/title: Add Network Policy for DNS
-    policies.nirmata.io/category: Multi-Tenancy, EKS Best Practices
-    policies.nirmata.io/subject: NetworkPolicy
+    policies.kyverno.io/title: Add Network Policy for DNS
+    policies.kyverno.io/category: Multi-Tenancy, EKS Best Practices
+    policies.kyverno.io/subject: NetworkPolicy
     kyverno.io/kyverno-version: 1.6.2
     policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kubernetes-version: "1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       By default, Kubernetes allows communications across all Pods within a cluster.
       The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict
       communications. A default NetworkPolicy should be configured for each Namespace to

--- a/best-practices/add_ns_quota/add_ns_quota.yaml
+++ b/best-practices/add_ns_quota/add_ns_quota.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: add-ns-quota
   annotations:
-    policies.nirmata.io/title: Add Quota
-    policies.nirmata.io/category: Multi-Tenancy, EKS Best Practices
-    policies.nirmata.io/subject: ResourceQuota, LimitRange
+    policies.kyverno.io/title: Add Quota
+    policies.kyverno.io/category: Multi-Tenancy, EKS Best Practices
+    policies.kyverno.io/subject: ResourceQuota, LimitRange
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       To better control the number of resources that can be created in a given
       Namespace and provide default resource consumption limits for Pods,
       ResourceQuota and LimitRange resources are recommended.

--- a/best-practices/add_rolebinding/add_rolebinding.yaml
+++ b/best-practices/add_rolebinding/add_rolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: add-rolebinding
   annotations:
-    policies.nirmata.io/title: Add RoleBinding
-    policies.nirmata.io/category: Multi-Tenancy
-    policies.nirmata.io/subject: RoleBinding
+    policies.kyverno.io/title: Add RoleBinding
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/subject: RoleBinding
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Typically in multi-tenancy and other use cases, when a new Namespace is created,
       users and other principals must be given some permissions to create and interact
       with resources in the Namespace. Very commonly, Roles and RoleBindings are used to

--- a/best-practices/add_safe_to_evict/add_safe_to_evict.yaml
+++ b/best-practices/add_safe_to_evict/add_safe_to_evict.yaml
@@ -3,10 +3,10 @@ kind: ClusterPolicy
 metadata:
   name: add-safe-to-evict
   annotations:
-    policies.nirmata.io/category: Other
-    policies.nirmata.io/subject: Pod,Annotation
+    policies.kyverno.io/category: Other
+    policies.kyverno.io/subject: Pod,Annotation
     policies.kyverno.io/minversion: 1.4.3
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       The Kubernetes cluster autoscaler does not evict pods that 
       use hostPath or emptyDir volumes. To allow eviction of these pods, the annotation 
       cluster-autoscaler.kubernetes.io/safe-to-evict=true must be added to the pods. 

--- a/best-practices/check_deprecated_apis/check_deprecated_apis.yaml
+++ b/best-practices/check_deprecated_apis/check_deprecated_apis.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: check-deprecated-apis
   annotations:
-    policies.nirmata.io/title: Check deprecated APIs
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/subject: Kubernetes APIs
+    policies.kyverno.io/title: Check deprecated APIs
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/subject: Kubernetes APIs
     kyverno.io/kyverno-version: 1.7.4
     policies.kyverno.io/minversion: 1.7.4
     kyverno.io/kubernetes-version: "1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Kubernetes APIs are sometimes deprecated and removed after a few releases.
       As a best practice, older API versions should be replaced with newer versions.
       This policy validates for APIs that are deprecated or scheduled for removal.

--- a/best-practices/disallow-empty-ingress-host/disallow_empty_ingress_host.yaml
+++ b/best-practices/disallow-empty-ingress-host/disallow_empty_ingress_host.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: disallow-empty-ingress-host
   annotations:
-    policies.nirmata.io/title: Disallow empty Ingress host
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Ingress
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/title: Disallow empty Ingress host
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
       An ingress resource needs to define an actual host name
       in order to be valid. This policy ensures that there is a
       hostname for each rule defined.

--- a/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
+++ b/best-practices/disallow_cri_sock_mount/disallow_cri_sock_mount.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: disallow-container-sock-mounts
   annotations:
-    policies.nirmata.io/title: Disallow CRI socket mounts
-    policies.nirmata.io/category: Best Practices, EKS Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow CRI socket mounts
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Container daemon socket bind mounts allows access to the container engine on the
       node. This access can be used for privilege escalation and to manage containers
       outside of Kubernetes, and hence should not be allowed. This policy validates that

--- a/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
+++ b/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-default-namespace
   annotations:
-    pod-policies.nirmata.io/autogen-controllers: none
-    policies.nirmata.io/title: Disallow Default Namespace
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/title: Disallow Default Namespace
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/category: Multi-Tenancy
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Kubernetes Namespaces are an optional feature that provide a way to segment and
       isolate cluster resources across multiple applications and users. As a best
       practice, workloads should be isolated with Namespaces. Namespaces should be required

--- a/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
+++ b/best-practices/disallow_helm_tiller/disallow_helm_tiller.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: disallow-helm-tiller
   annotations:
-    policies.nirmata.io/title: Disallow Helm Tiller
-    policies.nirmata.io/category: Sample
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/title: Disallow Helm Tiller
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Tiller, found in Helm v2, has known security challenges. It requires administrative privileges and acts as a shared
       resource accessible to any authenticated user. Tiller can lead to privilege escalation as
       restricted users can impact other users. It is recommend to use Helm v3+ which does not contain

--- a/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/best-practices/disallow_latest_tag/disallow_latest_tag.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: disallow-latest-tag
   annotations:
-    policies.nirmata.io/title: Disallow Latest Tag
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/title: Disallow Latest Tag
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       The ':latest' tag is mutable and can lead to unexpected errors if the
       image changes. A best practice is to use an immutable tag that maps to
       a specific version of an application Pod. This policy validates that the image

--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: drop-all-capabilities
   annotations:
-    policies.nirmata.io/title: Drop All Capabilities
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/severity: medium
+    policies.kyverno.io/title: Drop All Capabilities
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. All
       capabilities should be dropped from a Pod, with only those required added back.
       This policy ensures that all containers explicitly specify the `drop: ["ALL"]`

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: drop-cap-net-raw
   annotations:
-    policies.nirmata.io/title: Drop CAP_NET_RAW
-    policies.nirmata.io/category: Best Practices
+    policies.kyverno.io/title: Drop CAP_NET_RAW
+    policies.kyverno.io/category: Best Practices
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Capabilities permit privileged actions without giving full root access. The
       CAP_NET_RAW capability, enabled by default, allows processes in a container to
       forge packets and bind to any interface potentially leading to MitM attacks.

--- a/best-practices/require_labels/require_labels.yaml
+++ b/best-practices/require_labels/require_labels.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: require-labels
   annotations:
-    policies.nirmata.io/title: Require Labels
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod, Label
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/title: Require Labels
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Label
+    policies.kyverno.io/description: >-
       Define and use labels that identify semantic attributes of your application or Deployment.
       A common set of labels allows tools to work collaboratively, describing objects in a common manner that
       all tools can understand. The recommended labels describe applications in a way that can be

--- a/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
+++ b/best-practices/require_pod_requests_limits/require_pod_requests_limits.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: require-requests-limits
   annotations:
-    policies.nirmata.io/title: Require Limits and Requests
-    policies.nirmata.io/category: Best Practices, EKS Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Require Limits and Requests
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       As application workloads share cluster resources, it is important to limit resources
       requested and consumed by each Pod. It is recommended to require resource requests and
       limits per Pod, especially for memory and CPU. If a Namespace level request or limit is specified,

--- a/best-practices/require_probes/require_probes.yaml
+++ b/best-practices/require_probes/require_probes.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: require-pod-probes
   annotations:
-    pod-policies.nirmata.io/autogen-controllers: DaemonSet,Deployment,StatefulSet
-    policies.nirmata.io/title: Require Pod Probes
-    policies.nirmata.io/category: Best Practices, EKS Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    pod-policies.kyverno.io/autogen-controllers: DaemonSet,Deployment,StatefulSet
+    policies.kyverno.io/title: Require Pod Probes
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Liveness and readiness probes need to be configured to correctly manage a Pod's
       lifecycle during deployments, restarts, and upgrades. For each Pod, a periodic
       `livenessProbe` is performed by the kubelet to determine if the Pod's containers

--- a/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
+++ b/best-practices/require_ro_rootfs/require_ro_rootfs.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: require-ro-rootfs
   annotations:
-    policies.nirmata.io/title: Require Read-Only Root Filesystem
-    policies.nirmata.io/category: Best Practices, EKS Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Require Read-Only Root Filesystem
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       A read-only root file system helps to enforce an immutable infrastructure strategy;
       the container only needs to write on the mounted volume that persists the state.
       An immutable root filesystem can also prevent malicious binaries from writing to the

--- a/best-practices/restrict_image_registries/restrict_image_registries.yaml
+++ b/best-practices/restrict_image_registries/restrict_image_registries.yaml
@@ -3,12 +3,12 @@ kind: ClusterPolicy
 metadata:
   name: restrict-image-registries
   annotations:
-    policies.nirmata.io/title: Restrict Image Registries
-    policies.nirmata.io/category: Best Practices, EKS Best Practices
-    policies.nirmata.io/severity: medium
+    policies.kyverno.io/title: Restrict Image Registries
+    policies.kyverno.io/category: Best Practices, EKS Best Practices
+    policies.kyverno.io/severity: medium
     policies.kyverno.io/minversion: 1.6.0
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Images from unknown, public registries can be of dubious quality and may not be
       scanned and secured, representing a high degree of risk. Requiring use of known, approved
       registries helps reduce threat exposure by ensuring image pulls only come from them. This

--- a/best-practices/restrict_node_port/restrict_node_port.yaml
+++ b/best-practices/restrict_node_port/restrict_node_port.yaml
@@ -3,11 +3,11 @@ kind: ClusterPolicy
 metadata:
   name: restrict-nodeport
   annotations:
-    policies.nirmata.io/title: Disallow NodePort
-    policies.nirmata.io/category: Best Practices
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Service
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/title: Disallow NodePort
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
       A Kubernetes Service of type NodePort uses a host port to receive traffic from
       any source. A NetworkPolicy cannot be used to control traffic to host ports.
       Although NodePort Services can be useful, their use must be limited to Services

--- a/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
+++ b/pod-security/baseline/disallow-capabilities/disallow-capabilities.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: disallow-capabilities
   annotations:
-    policies.nirmata.io/title: Disallow Capabilities
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
+    policies.kyverno.io/title: Disallow Capabilities
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
     kyverno.io/kyverno-version: 1.6.0
-    policies.nirmata.io/minversion: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
 spec:
   validationFailureAction: audit

--- a/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/pod-security/baseline/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-host-namespaces
   annotations:
-    policies.nirmata.io/title: Disallow Host Namespaces
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
+    policies.kyverno.io/title: Disallow Host Namespaces
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
       network namespace) allow access to shared information and can be used to elevate
       privileges. Pods should not be allowed access to host namespaces. This policy ensures

--- a/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
+++ b/pod-security/baseline/disallow-host-path/disallow-host-path.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-host-path
   annotations:
-    policies.nirmata.io/title: Disallow hostPath
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod,Volume
+    policies.kyverno.io/title: Disallow hostPath
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod,Volume
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       HostPath volumes let Pods use host directories and volumes in containers.
       Using host resources can be used to access shared data or escalate privileges
       and should not be allowed. This policy ensures no hostPath volumes are in use.

--- a/pod-security/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
+++ b/pod-security/baseline/disallow-host-ports-range/disallow-host-ports-range.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: disallow-host-ports-range
   annotations:
-    policies.nirmata.io/title: Disallow hostPorts Range (Alternate)
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostPorts Range (Alternate)
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
-    policies.nirmata.io/minversion: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is set to one in the designated list. 

--- a/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
+++ b/pod-security/baseline/disallow-host-ports/disallow-host-ports.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-host-ports
   annotations:
-    policies.nirmata.io/title: Disallow hostPorts
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostPorts
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Access to host ports allows potential snooping of network traffic and should not be
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`. 

--- a/pod-security/baseline/disallow-host-process/disallow-host-process.yaml
+++ b/pod-security/baseline/disallow-host-process/disallow-host-process.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-host-process
   annotations:
-    policies.nirmata.io/title: Disallow hostProcess
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow hostProcess
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Windows pods offer the ability to run HostProcess containers which enables privileged
       access to the Windows node. Privileged access to the host is disallowed in the baseline
       policy. HostProcess pods are an alpha feature as of Kubernetes v1.22. This policy ensures

--- a/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
+++ b/pod-security/baseline/disallow-privileged-containers/disallow-privileged-containers.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-privileged-containers
   annotations:
-    policies.nirmata.io/title: Disallow Privileged Containers
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privileged Containers
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
 spec:

--- a/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
+++ b/pod-security/baseline/disallow-proc-mount/disallow-proc-mount.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-proc-mount
   annotations:
-    policies.nirmata.io/title: Disallow procMount
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow procMount
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       The default /proc masks are set up to reduce attack surface and should be required. This policy
       ensures nothing but the default procMount can be specified. Note that in order for users
       to deviate from the `Default` procMount requires setting a feature gate at the API

--- a/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
+++ b/pod-security/baseline/disallow-selinux/disallow-selinux.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-selinux
   annotations:
-    policies.nirmata.io/title: Disallow SELinux
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow SELinux
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
 spec:

--- a/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+++ b/pod-security/baseline/restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: restrict-apparmor-profiles
   annotations:
-    policies.nirmata.io/title: Restrict AppArmor
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod, Annotation
-    policies.nirmata.io/minversion: 1.3.0
+    policies.kyverno.io/title: Restrict AppArmor
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod, Annotation
+    policies.kyverno.io/minversion: 1.3.0
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       On supported hosts, the 'runtime/default' AppArmor profile is applied by default.
       The default policy should prevent overriding or disabling the policy, or restrict
       overrides to an allowed set of profiles. This policy ensures Pods do not

--- a/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
+++ b/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: restrict-seccomp
   annotations:
-    policies.nirmata.io/title: Restrict Seccomp
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Restrict Seccomp
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       The seccomp profile must not be explicitly set to Unconfined. This policy, 
       requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
       set to `RuntimeDefault` or `Localhost`.

--- a/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
+++ b/pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: restrict-sysctls
   annotations:
-    policies.nirmata.io/title: Restrict sysctls
-    policies.nirmata.io/category: Pod Security Standards (Baseline)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Restrict sysctls
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Sysctls can disable security mechanisms or affect all containers on a
       host, and should be disallowed except for an allowed "safe" subset. A
       sysctl is considered safe if it is namespaced in the container or the

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: disallow-capabilities-strict
   annotations:
-    policies.nirmata.io/title: Disallow Capabilities (Strict)
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/minversion: 1.6.0
+    policies.kyverno.io/title: Disallow Capabilities (Strict)
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/subject: Pod
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
       Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition,
       all containers must explicitly drop `ALL` capabilities.
 spec:

--- a/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: disallow-privilege-escalation
   annotations:
-    policies.nirmata.io/title: Disallow Privilege Escalation
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Disallow Privilege Escalation
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:

--- a/pod-security/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/pod-security/restricted/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: require-run-as-non-root-user
   annotations:
-    policies.nirmata.io/title: Require Run As Non-Root User
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Require Run As Non-Root User
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Containers must be required to run as non-root users. This policy ensures
       `runAsUser` is either unset or set to a number greater than zero.
 spec:

--- a/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
+++ b/pod-security/restricted/require-run-as-nonroot/require-run-as-nonroot.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: require-run-as-nonroot
   annotations:
-    policies.nirmata.io/title: Require runAsNonRoot
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Require runAsNonRoot
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       Containers must be required to run as non-root users. This policy ensures
       `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.

--- a/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
+++ b/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict.yaml
@@ -3,13 +3,13 @@ kind: ClusterPolicy
 metadata:
   name: restrict-seccomp-strict
   annotations:
-    policies.nirmata.io/title: Restrict Seccomp (Strict)
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod
+    policies.kyverno.io/title: Restrict Seccomp (Strict)
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       The seccomp profile in the Restricted group must not be explicitly set to Unconfined
       but additionally must also not allow an unset value. This policy, 
       requiring Kubernetes v1.19 or later, ensures that seccomp is 

--- a/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
+++ b/pod-security/restricted/restrict-volume-types/restrict-volume-types.yaml
@@ -3,14 +3,14 @@ kind: ClusterPolicy
 metadata:
   name: restrict-volume-types
   annotations:
-    policies.nirmata.io/title: Restrict Volume Types
-    policies.nirmata.io/category: Pod Security Standards (Restricted)
-    policies.nirmata.io/severity: medium
-    policies.nirmata.io/subject: Pod,Volume
-    policies.nirmata.io/minversion: 1.6.0
+    policies.kyverno.io/title: Restrict Volume Types
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod,Volume
+    policies.kyverno.io/minversion: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
     kyverno.io/kyverno-version: 1.6.0
-    policies.nirmata.io/description: >-
+    policies.kyverno.io/description: >-
       In addition to restricting HostPath volumes, the restricted pod security profile
       limits usage of non-core volume types to those defined through PersistentVolumes.
       This policy blocks any other type of volume other than those in the allow list.


### PR DESCRIPTION
Until nirmata.io annotation is supported in NPM, we will continue to use policies.kyverno.io annotation in the policies.
TODO: update once NPM support is available