### PR TITLE
Update overlay field

### DIFF
--- a/multitenancy/add-roles.yaml
+++ b/multitenancy/add-roles.yaml
@@ -16,7 +16,7 @@ spec:
         kinds:
         - Namespace
     mutate:
-      overlay:
+      patchStrategicMerge:
         metadata:
           annotations:
             nirmata.io/ns-creator: "{{serviceAccountName}}"


### PR DESCRIPTION
overlay field is not supported in latest kyverno versions. Replaced it with patchStrategicMerge.

Sample output
```
> k apply -f multitenancy
clusterpolicy.kyverno.io/add-network-policy unchanged
clusterpolicy.kyverno.io/add-ns-access-controls created
```