### PR TITLE
Disable running kuttl test on PRs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
-    branches:
-      - 'main'
+  # this action needs to read GH secret
+  # hence prevents executing on PRs from forks
+  # disabling running on PRs until we find a workaround for this
+  # pull_request:
+  #   branches:
+  #     - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Kuttl tests need to read license key from GH secret. This is not possible for PRs from forks. Hence, disabling this test on PRs.
Kuttl tests will run when a PR is merged to main.