### PR TITLE
chore: remove titlecase for compat with kyverno 1.8

### DIFF
--- a/charts/best-practices-k8s/Chart.yaml
+++ b/charts/best-practices-k8s/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-best-practice-policies
 description: Kubernetes Best Practice policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/best-practices-k8s/pols/check_deprecated_apis.yaml
+++ b/charts/best-practices-k8s/pols/check_deprecated_apis.yaml
@@ -21,7 +21,7 @@ metadata:
       so therefore the validate-v1-25-removals rule may not completely work on 1.25+.
       This policy requires Kyverno v1.7.4+ to function properly.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-v1-22-removals

--- a/charts/best-practices-k8s/pols/disallow_cri_sock_mount.yaml
+++ b/charts/best-practices-k8s/pols/disallow_cri_sock_mount.yaml
@@ -14,7 +14,7 @@ metadata:
       outside of Kubernetes, and hence should not be allowed. This policy validates that
       the sockets used for CRI engines Docker, Containerd, and CRI-O are not used.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-docker-sock-mount

--- a/charts/best-practices-k8s/pols/disallow_default_namespace.yaml
+++ b/charts/best-practices-k8s/pols/disallow_default_namespace.yaml
@@ -18,7 +18,7 @@ metadata:
       due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
       object and not at the Pod template level.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-namespace

--- a/charts/best-practices-k8s/pols/disallow_empty_ingress_host.yaml
+++ b/charts/best-practices-k8s/pols/disallow_empty_ingress_host.yaml
@@ -12,7 +12,7 @@ metadata:
       in order to be valid. This policy ensures that there is a
       hostname for each rule defined.
 spec:
-  validationFailureAction: Enforce
+  validationFailureAction: enforce
   background: false
   rules:
     - name: disallow-empty-ingress-host

--- a/charts/best-practices-k8s/pols/disallow_latest_tag.yaml
+++ b/charts/best-practices-k8s/pols/disallow_latest_tag.yaml
@@ -13,7 +13,7 @@ metadata:
       a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: require-image-tag

--- a/charts/best-practices-k8s/pols/require_drop_all.yaml
+++ b/charts/best-practices-k8s/pols/require_drop_all.yaml
@@ -15,7 +15,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: require-drop-all

--- a/charts/best-practices-k8s/pols/require_drop_cap_net_raw.yaml
+++ b/charts/best-practices-k8s/pols/require_drop_cap_net_raw.yaml
@@ -16,7 +16,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: require-drop-cap-net-raw

--- a/charts/best-practices-k8s/pols/require_labels.yaml
+++ b/charts/best-practices-k8s/pols/require_labels.yaml
@@ -13,7 +13,7 @@ metadata:
       all tools can understand. The recommended labels describe applications in a way that can be
       queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: check-for-labels

--- a/charts/best-practices-k8s/pols/require_pod_requests_limits.yaml
+++ b/charts/best-practices-k8s/pols/require_pod_requests_limits.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy validates that all containers have something specified for memory and CPU
       requests and memory limits.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-resources

--- a/charts/best-practices-k8s/pols/require_probes.yaml
+++ b/charts/best-practices-k8s/pols/require_probes.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy validates that all containers have one of livenessProbe, readinessProbe,
       or startupProbe defined.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-probes

--- a/charts/best-practices-k8s/pols/require_ro_rootfs.yaml
+++ b/charts/best-practices-k8s/pols/require_ro_rootfs.yaml
@@ -15,7 +15,7 @@ metadata:
       host system. This policy validates that containers define a securityContext
       with `readOnlyRootFilesystem: true`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-readOnlyRootFilesystem

--- a/charts/best-practices-k8s/pols/restrict-service-external-ips.yaml
+++ b/charts/best-practices-k8s/pols/restrict-service-external-ips.yaml
@@ -13,7 +13,7 @@ metadata:
       See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: check-ips

--- a/charts/best-practices-k8s/pols/restrict_image_registries.yaml
+++ b/charts/best-practices-k8s/pols/restrict_image_registries.yaml
@@ -15,7 +15,7 @@ metadata:
       policy validates that container images only originate from the registry `eu.foo.io` or
       `bar.io`. Use of this policy requires customization to define your allowable registries.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-registries

--- a/charts/best-practices-k8s/pols/restrict_node_port.yaml
+++ b/charts/best-practices-k8s/pols/restrict_node_port.yaml
@@ -14,7 +14,7 @@ metadata:
       with additional upstream security checks. This policy validates that any new Services
       do not use the `NodePort` type.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-nodeport

--- a/charts/best-practices-workload-security/Chart.yaml
+++ b/charts/best-practices-workload-security/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: workload-security-best-practice-policies
 description: Workload Security Best Practice policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/best-practices-workload-security/pols/disallow_cri_sock_mount.yaml
+++ b/charts/best-practices-workload-security/pols/disallow_cri_sock_mount.yaml
@@ -14,7 +14,7 @@ metadata:
       outside of Kubernetes, and hence should not be allowed. This policy validates that
       the sockets used for CRI engines Docker, Containerd, and CRI-O are not used.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-docker-sock-mount

--- a/charts/best-practices-workload-security/pols/disallow_default_namespace.yaml
+++ b/charts/best-practices-workload-security/pols/disallow_default_namespace.yaml
@@ -18,7 +18,7 @@ metadata:
       due to Pod controllers need to specify the `namespace` field under the top-level `metadata`
       object and not at the Pod template level.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-namespace

--- a/charts/best-practices-workload-security/pols/disallow_empty_ingress_host.yaml
+++ b/charts/best-practices-workload-security/pols/disallow_empty_ingress_host.yaml
@@ -12,7 +12,7 @@ metadata:
       in order to be valid. This policy ensures that there is a
       hostname for each rule defined.
 spec:
-  validationFailureAction: Enforce
+  validationFailureAction: enforce
   background: false
   rules:
     - name: disallow-empty-ingress-host

--- a/charts/best-practices-workload-security/pols/disallow_latest_tag.yaml
+++ b/charts/best-practices-workload-security/pols/disallow_latest_tag.yaml
@@ -13,7 +13,7 @@ metadata:
       a specific version of an application Pod. This policy validates that the image
       specifies a tag and that it is not called `latest`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: require-image-tag

--- a/charts/best-practices-workload-security/pols/require_drop_all.yaml
+++ b/charts/best-practices-workload-security/pols/require_drop_all.yaml
@@ -15,7 +15,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: require-drop-all

--- a/charts/best-practices-workload-security/pols/require_drop_cap_net_raw.yaml
+++ b/charts/best-practices-workload-security/pols/require_drop_cap_net_raw.yaml
@@ -16,7 +16,7 @@ metadata:
       ability. Note that this policy also illustrates how to cover drop entries in any
       case although this may not strictly conform to the Pod Security Standards.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: require-drop-cap-net-raw

--- a/charts/best-practices-workload-security/pols/require_labels.yaml
+++ b/charts/best-practices-workload-security/pols/require_labels.yaml
@@ -13,7 +13,7 @@ metadata:
       all tools can understand. The recommended labels describe applications in a way that can be
       queried. This policy validates that the label `app.kubernetes.io/name` is specified with some value.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: check-for-labels

--- a/charts/best-practices-workload-security/pols/require_pod_requests_limits.yaml
+++ b/charts/best-practices-workload-security/pols/require_pod_requests_limits.yaml
@@ -16,7 +16,7 @@ metadata:
       This policy validates that all containers have something specified for memory and CPU
       requests and memory limits.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-resources

--- a/charts/best-practices-workload-security/pols/require_probes.yaml
+++ b/charts/best-practices-workload-security/pols/require_probes.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy validates that all containers have one of livenessProbe, readinessProbe,
       or startupProbe defined.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-probes

--- a/charts/best-practices-workload-security/pols/require_ro_rootfs.yaml
+++ b/charts/best-practices-workload-security/pols/require_ro_rootfs.yaml
@@ -15,7 +15,7 @@ metadata:
       host system. This policy validates that containers define a securityContext
       with `readOnlyRootFilesystem: true`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-readOnlyRootFilesystem

--- a/charts/best-practices-workload-security/pols/restrict-service-external-ips.yaml
+++ b/charts/best-practices-workload-security/pols/restrict-service-external-ips.yaml
@@ -13,7 +13,7 @@ metadata:
       See: https://github.com/kyverno/kyverno/issues/1367. This policy validates
       that the `externalIPs` field is not set on a Service.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: check-ips

--- a/charts/best-practices-workload-security/pols/restrict_image_registries.yaml
+++ b/charts/best-practices-workload-security/pols/restrict_image_registries.yaml
@@ -15,7 +15,7 @@ metadata:
       policy validates that container images only originate from the registry `eu.foo.io` or
       `bar.io`. Use of this policy requires customization to define your allowable registries.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-registries

--- a/charts/best-practices-workload-security/pols/restrict_node_port.yaml
+++ b/charts/best-practices-workload-security/pols/restrict_node_port.yaml
@@ -14,7 +14,7 @@ metadata:
       with additional upstream security checks. This policy validates that any new Services
       do not use the `NodePort` type.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-nodeport

--- a/charts/multitenancy/Chart.yaml
+++ b/charts/multitenancy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: multitenancy-best-practice-policies
 description: Multitenancy Best Practices policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/multitenancy/pols/allowed-podpriorities.yaml
+++ b/charts/multitenancy/pols/allowed-podpriorities.yaml
@@ -15,7 +15,7 @@ metadata:
       PriorityClasses for the given Namespace stored in a ConfigMap. If the `priorityClassName` is not
       among them, the Pod is blocked.      
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-pod-priority

--- a/charts/pod-security-baseline/Chart.yaml
+++ b/charts/pod-security-baseline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pss-baseline-policies
 description: Pod Security Standards (baseline) policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/pod-security-baseline/pols/disallow-capabilities.yaml
+++ b/charts/pod-security-baseline/pols/disallow-capabilities.yaml
@@ -13,7 +13,7 @@ metadata:
     policies.kyverno.io/description: >-
       Adding capabilities beyond those listed in the policy must be disallowed.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: adding-capabilities

--- a/charts/pod-security-baseline/pols/disallow-host-namespaces.yaml
+++ b/charts/pod-security-baseline/pols/disallow-host-namespaces.yaml
@@ -15,7 +15,7 @@ metadata:
       privileges. Pods should not be allowed access to host namespaces. This policy ensures
       fields which make use of these host namespaces are unset or set to `false`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: host-namespaces

--- a/charts/pod-security-baseline/pols/disallow-host-path.yaml
+++ b/charts/pod-security-baseline/pols/disallow-host-path.yaml
@@ -14,7 +14,7 @@ metadata:
       Using host resources can be used to access shared data or escalate privileges
       and should not be allowed. This policy ensures no hostPath volumes are in use.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: host-path

--- a/charts/pod-security-baseline/pols/disallow-host-ports-range.yaml
+++ b/charts/pod-security-baseline/pols/disallow-host-ports-range.yaml
@@ -15,7 +15,7 @@ metadata:
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is set to one in the designated list. 
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: host-port-range

--- a/charts/pod-security-baseline/pols/disallow-host-ports.yaml
+++ b/charts/pod-security-baseline/pols/disallow-host-ports.yaml
@@ -14,7 +14,7 @@ metadata:
       allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
       field is unset or set to `0`. 
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: host-ports-none

--- a/charts/pod-security-baseline/pols/disallow-host-process.yaml
+++ b/charts/pod-security-baseline/pols/disallow-host-process.yaml
@@ -15,7 +15,7 @@ metadata:
       policy. HostProcess pods are an alpha feature as of Kubernetes v1.22. This policy ensures
       the `hostProcess` field, if present, is set to `false`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: host-process-containers

--- a/charts/pod-security-baseline/pols/disallow-privileged-containers.yaml
+++ b/charts/pod-security-baseline/pols/disallow-privileged-containers.yaml
@@ -13,7 +13,7 @@ metadata:
       Privileged mode disables most security mechanisms and must not be allowed. This policy
       ensures Pods do not call for privileged mode.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: privileged-containers

--- a/charts/pod-security-baseline/pols/disallow-proc-mount.yaml
+++ b/charts/pod-security-baseline/pols/disallow-proc-mount.yaml
@@ -15,7 +15,7 @@ metadata:
       to deviate from the `Default` procMount requires setting a feature gate at the API
       server.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: check-proc-mount

--- a/charts/pod-security-baseline/pols/disallow-selinux.yaml
+++ b/charts/pod-security-baseline/pols/disallow-selinux.yaml
@@ -13,7 +13,7 @@ metadata:
       SELinux options can be used to escalate privileges and should not be allowed. This policy
       ensures that the `seLinuxOptions` field is undefined.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: selinux-type

--- a/charts/pod-security-baseline/pols/restrict-apparmor-profiles.yaml
+++ b/charts/pod-security-baseline/pols/restrict-apparmor-profiles.yaml
@@ -16,7 +16,7 @@ metadata:
       overrides to an allowed set of profiles. This policy ensures Pods do not
       specify any other AppArmor profiles than `runtime/default` or `localhost/*`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: app-armor

--- a/charts/pod-security-baseline/pols/restrict-seccomp.yaml
+++ b/charts/pod-security-baseline/pols/restrict-seccomp.yaml
@@ -15,7 +15,7 @@ metadata:
       set to `RuntimeDefault` or `Localhost`.
 spec:
   background: true
-  validationFailureAction: Audit
+  validationFailureAction: audit
   rules:
     - name: check-seccomp
       match:

--- a/charts/pod-security-baseline/pols/restrict-sysctls.yaml
+++ b/charts/pod-security-baseline/pols/restrict-sysctls.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy ensures that only those "safe" subsets can be specified in
       a Pod.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: check-sysctls

--- a/charts/pod-security-restricted/Chart.yaml
+++ b/charts/pod-security-restricted/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pss-restricted-policies
 description: Pod Security Standards (restricted) policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/pod-security-restricted/pols/disallow-capabilities-strict.yaml
+++ b/charts/pod-security-restricted/pols/disallow-capabilities-strict.yaml
@@ -14,7 +14,7 @@ metadata:
       Adding capabilities other than `NET_BIND_SERVICE` is disallowed. In addition,
       all containers must explicitly drop `ALL` capabilities.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: require-drop-all

--- a/charts/pod-security-restricted/pols/disallow-privilege-escalation.yaml
+++ b/charts/pod-security-restricted/pols/disallow-privilege-escalation.yaml
@@ -13,7 +13,7 @@ metadata:
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: privilege-escalation

--- a/charts/pod-security-restricted/pols/require-run-as-non-root-user.yaml
+++ b/charts/pod-security-restricted/pols/require-run-as-non-root-user.yaml
@@ -13,7 +13,7 @@ metadata:
       Containers must be required to run as non-root users. This policy ensures
       `runAsUser` is either unset or set to a number greater than zero.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: run-as-non-root-user

--- a/charts/pod-security-restricted/pols/require-run-as-nonroot.yaml
+++ b/charts/pod-security-restricted/pols/require-run-as-nonroot.yaml
@@ -14,7 +14,7 @@ metadata:
       `runAsNonRoot` is set to `true`. A known issue prevents a policy such as this
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: run-as-non-root

--- a/charts/pod-security-restricted/pols/restrict-seccomp-strict.yaml
+++ b/charts/pod-security-restricted/pols/restrict-seccomp-strict.yaml
@@ -17,7 +17,7 @@ metadata:
       using `anyPattern` from being persisted properly in Kubernetes 1.23.0-1.23.2.
 spec:
   background: true
-  validationFailureAction: Audit
+  validationFailureAction: audit
   rules:
     - name: check-seccomp-strict
       match:

--- a/charts/pod-security-restricted/pols/restrict-volume-types.yaml
+++ b/charts/pod-security-restricted/pols/restrict-volume-types.yaml
@@ -15,7 +15,7 @@ metadata:
       limits usage of non-core volume types to those defined through PersistentVolumes.
       This policy blocks any other type of volume other than those in the allow list.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: restricted-volumes

--- a/charts/rbac-best-practices/Chart.yaml
+++ b/charts/rbac-best-practices/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rbac-best-practice-policies
 description: Rbac Best Practice policy set
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - kubernetes

--- a/charts/rbac-best-practices/pols/restrict-automount-sa-token.yaml
+++ b/charts/rbac-best-practices/pols/restrict-automount-sa-token.yaml
@@ -15,7 +15,7 @@ metadata:
       be followed if Pods do not need to speak to the API server to function.
       This policy ensures that mounting of these ServiceAccount tokens is blocked.      
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
   - name: validate-automountServiceAccountToken

--- a/charts/rbac-best-practices/pols/restrict-binding-system-groups.yaml
+++ b/charts/rbac-best-practices/pols/restrict-binding-system-groups.yaml
@@ -15,7 +15,7 @@ metadata:
       are used for certain system-level functions yet typically never appropriate
       for other users. This policy prevents creating bindings for system:masters group.      
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: restrict-masters

--- a/charts/rbac-best-practices/pols/restrict-clusterrole-nodesproxy.yaml
+++ b/charts/rbac-best-practices/pols/restrict-clusterrole-nodesproxy.yaml
@@ -18,7 +18,7 @@ metadata:
       for more info. This policy prevents the creation
       of a ClusterRole if it contains the nodes/proxy resource.       
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: clusterrole-nodesproxy

--- a/charts/rbac-best-practices/pols/restrict-escalation-verbs-roles.yaml
+++ b/charts/rbac-best-practices/pols/restrict-escalation-verbs-roles.yaml
@@ -15,7 +15,7 @@ metadata:
       privilege escalation and should be tightly controlled. This policy prevents
       use of these verbs in Role or ClusterRole resources.      
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: escalate

--- a/charts/rbac-best-practices/pols/restrict-wildcard-resources.yaml
+++ b/charts/rbac-best-practices/pols/restrict-wildcard-resources.yaml
@@ -17,7 +17,7 @@ metadata:
       This policy blocks any Role or ClusterRole that contains a wildcard entry in
       the resources list found in any rule.      
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: audit
   background: true
   rules:
     - name: wildcard-resources


### PR DESCRIPTION
Kyverno 1.8 does not support titlecase in validationFailureAction. So setting it to lower case. Will give a deprecation warning when policies are created, but ok.