### PR TITLE
Update delete operations in preconditions

### DIFF
--- a/best-practices/require_drop_all/require_drop_all.yaml
+++ b/best-practices/require_drop_all/require_drop_all.yaml
@@ -25,11 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.

--- a/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
+++ b/best-practices/require_drop_cap_net_raw/require_drop_cap_net_raw.yaml
@@ -26,11 +26,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop the `CAP_NET_RAW` capability.

--- a/charts/best-practices-k8s/pols/require_drop_all.yaml
+++ b/charts/best-practices-k8s/pols/require_drop_all.yaml
@@ -25,11 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.

--- a/charts/best-practices-k8s/pols/require_drop_cap_net_raw.yaml
+++ b/charts/best-practices-k8s/pols/require_drop_cap_net_raw.yaml
@@ -26,11 +26,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop the `CAP_NET_RAW` capability.

--- a/charts/best-practices-workload-security/pols/require_drop_all.yaml
+++ b/charts/best-practices-workload-security/pols/require_drop_all.yaml
@@ -24,11 +24,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.

--- a/charts/best-practices-workload-security/pols/require_drop_cap_net_raw.yaml
+++ b/charts/best-practices-workload-security/pols/require_drop_cap_net_raw.yaml
@@ -25,11 +25,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
           Containers must drop the `CAP_NET_RAW` capability.

--- a/charts/pod-security-restricted/pols/disallow-capabilities-strict.yaml
+++ b/charts/pod-security-restricted/pols/disallow-capabilities-strict.yaml
@@ -24,11 +24,9 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.operation || 'BACKGROUND' }}"
-            operator: NotEquals
-            value: DELETE
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.
@@ -46,11 +44,9 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.operation || 'BACKGROUND' }}"
-            operator: NotEquals
-            value: DELETE
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         message: >-
           Any capabilities added other than NET_BIND_SERVICE are disallowed.

--- a/eks-best-practices/allowed-base-images.yaml
+++ b/eks-best-practices/allowed-base-images.yaml
@@ -25,11 +25,9 @@ spec:
       - resources:
           kinds:
           - Pod
-    preconditions:
-      all:
-      - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: NotEquals
-        value: DELETE
+          operations:
+          - CREATE
+          - UPDATE
     context:
     - name: baseimages
       configMap:

--- a/eks-best-practices/require-base-image.yaml
+++ b/eks-best-practices/require-base-image.yaml
@@ -28,11 +28,9 @@ spec:
       - resources:
           kinds:
           - Pod
-    preconditions:
-      all:
-      - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: NotEquals
-        value: DELETE
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       message: "Images must specify a source/base image from which they are built."
       foreach:

--- a/eks-best-practices/restrict-adding-capabilities.yaml
+++ b/eks-best-practices/restrict-adding-capabilities.yaml
@@ -26,11 +26,9 @@ spec:
         - resources:
             kinds:
               - Pod
-      preconditions:
-        all:
-        - key: "{{ request.operation || 'BACKGROUND' }}"
-          operator: NotEquals
-          value: DELETE
+            operations:
+            - CREATE
+            - UPDATE
       validate:
         message: >-
                     Any capabilities added other than NET_BIND_SERVICE or CAP_CHOWN are disallowed.

--- a/finops/prevent_orphan_pods.yaml
+++ b/finops/prevent_orphan_pods.yaml
@@ -26,11 +26,9 @@ spec:
       - resources:
           kinds:
           - Pod
-    preconditions:
-      all:
-      - key: "{{request.operation || 'BACKGROUND'}}"
-        operator: NotEquals
-        value: DELETE
+          operations:
+          - CREATE
+          - UPDATE
     validate:
       message: "Naked Pods are not allowed. They must be created by Pod controllers."
       deny:

--- a/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/disallow-capabilities-strict.yaml
@@ -23,11 +23,9 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.operation || 'BACKGROUND' }}"
-            operator: NotEquals
-            value: DELETE
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         message: >-
           Containers must drop `ALL` capabilities.
@@ -45,11 +43,9 @@ spec:
           - resources:
               kinds:
                 - Pod
-      preconditions:
-        all:
-          - key: "{{ request.operation || 'BACKGROUND' }}"
-            operator: NotEquals
-            value: DELETE
+              operations:
+              - CREATE
+              - UPDATE
       validate:
         message: >-
           Any capabilities added other than NET_BIND_SERVICE are disallowed.


### PR DESCRIPTION
Sample policy compatible with 1.10 - https://kyverno.io/policies/other/audit-event-on-delete/audit-event-on-delete/

In Kyverno 1.10, matching on operations is preferred over preconditions specifying inclusion or exclusion of operations. E.g., `DELETE` in deny and foreach blocks. This PR updates all such policies to be compatible with 1.10. 

**Note:** This is not backwards compatible.