### PR TITLE
NDEV-17930: set allowPrivilegeEscalation to false even if securityContext is not defined

### DIFF
--- a/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
+++ b/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml
@@ -10,7 +10,7 @@ metadata:
     kyverno.io/kyverno-version: 1.6.0
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.nirmata.io/remediation-docs: "https://docs.nirmata.io/policysets/podsecurity/restricted/disallow-privilege-escalation/"
-    policies.nirmata.io/remediation: "https://github.com/nirmata/kyverno-policies/tree/main/pod-security/restricted/disallow-privilege-escalation/remediate-diallow-privilege-escalation.yaml"
+    policies.nirmata.io/remediation: "https://github.com/nirmata/kyverno-policies/tree/main/pod-security/restricted/disallow-privilege-escalation/remediate-disallow-privilege-escalation.yaml"
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
       This policy ensures the fields

--- a/pod-security/restricted/disallow-privilege-escalation/remediate-disallow-privilege-escalation.yaml
+++ b/pod-security/restricted/disallow-privilege-escalation/remediate-disallow-privilege-escalation.yaml
@@ -39,15 +39,12 @@ spec:
                   containers:
                     - (name): "{{ element.name }}"
                       securityContext:
-                        (allowPrivilegeEscalation): true
                         allowPrivilegeEscalation: false
                   initContainers:
                     - (name): "{{ element.name }}"
                       securityContext:
-                        (allowPrivilegeEscalation): true
                         allowPrivilegeEscalation: false
                   ephemeralContainers:
                     - (name): "{{ element.name }}"
                       securityContext:
-                        (allowPrivilegeEscalation): true
                         allowPrivilegeEscalation: false


### PR DESCRIPTION
* If `securityContext.allowPrivilegeEscalation` is not defined for a container, the [disallow-privilege-escalation validate policy](https://github.com/nirmata/kyverno-policies/blob/main/pod-security/restricted/disallow-privilege-escalation/disallow-privilege-escalation.yaml) fails. But, the mutate policy we defined will not make any changes to the resource. 

* The updated mutate policy will set the `securityContext.allowPrivilegeEscalation` to `false` even if `securityContext.allowPriviligeEscalation` is not defined. 