### PR TITLE
chore: update chainsaw to `v0.1.4`

### DIFF
--- a/.github/workflows/chainsaw-e2e.yaml
+++ b/.github/workflows/chainsaw-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
         run: make wait-for-kyverno
 
       - name: Install Chainsaw
-        uses: kyverno/action-install-chainsaw@v0.1.4 
+        uses: kyverno/action-install-chainsaw@v0.1.6 
 
       - name: Verify Chainsaw Installation
         run: chainsaw version


### PR DESCRIPTION
This is to make sure that the chainsaw tests I write with the latest patch method syntax works.

Patch Method valid for `v0.1.6`

```
    patch:
        resource:
          apiVersion: kyverno.io/v1
          kind: ClusterPolicy
          metadata:
            name: require-resource-quota
          spec:
            validationFailureAction: Enforce```
```
Script Method for `v0.1.4`
```
    - script:
         content: |
             sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' ../require-resource-quota.yaml | kubectl apply -f - 
```