### PR TITLE
NDEV-19889 : exclude the nirmata resources from the policy

### DIFF
--- a/rbac-best-practices/restrict-automount-sa-token/restrict-automount-sa-token.yaml
+++ b/rbac-best-practices/restrict-automount-sa-token/restrict-automount-sa-token.yaml
@@ -24,6 +24,62 @@ spec:
       - resources:
           kinds:
           - Pod
+    exclude:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app: nirmata-kube-controller
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app: otel-agent
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: nirmata-kyverno-operator
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: admission-controller    
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: cleanup-controller    
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: background-controller    
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: reports-controller    
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              batch.kubernetes.io/job-name: "kyverno-cleanup-admission-reports-*"   
+      - resources:
+          kinds:
+          - Pod
+          selector:
+            matchLabels:
+              batch.kubernetes.io/job-name=kyverno: "cleanup-cluster-admission-reports-*" 
     preconditions:
       all:
       - key: "{{ request.\"object\".metadata.labels.\"app.kubernetes.io/part-of\" || '' }}"


### PR DESCRIPTION
**Description:**

<!-- Provide a brief description of your changes. -->
Nirmata deployed components should not fail their own policysets, this fix excludes the nirmata components from the specific policy which they are failing.

**Related Issues:**

<!-- List any related issues or tasks. -->

[JIRA](https://nirmata.atlassian.net/browse/NDEV-19889)

**Checklist:**
<!-- Add a `x` to mark the checkboxes as done. -->
- [ ] This PR requires a bump in kyverno-policies chart version .
- [ ] I have created a PR to bump the enterprise-kyverno-operator chart version.

