### PR TITLE
NDEV-20544: add remediate policies for RBAC best practices

### DIFF
--- a/rbac-best-practices/restrict-automount-sa-token/e2e/chainsaw-test.yaml
+++ b/rbac-best-practices/restrict-automount-sa-token/e2e/chainsaw-test.yaml
@@ -3,7 +3,6 @@ kind: Test
 metadata:
   name: restrict-automount-sa-token-policy
 spec:
-  namespace: default
   steps:
   - name: test-restrict-automount-sa-token
     try:
@@ -11,30 +10,6 @@ spec:
         file: ../restrict-automount-sa-token.yaml
     - assert:
         file: policy-assert.yaml
-    - apply:
-        file: ../remediate-restrict-automount-sa-token.yaml
-    - assert:
-        file: remediation-policy-assert.yaml
-    - apply:
-        file: bad-resource.yaml
-    - sleep:
-        duration: 20s
-    - assert:
-        resource:
-          apiVersion: wgpolicyk8s.io/v1alpha2
-          kind: PolicyReport
-          summary:
-            error: 0
-            fail: 0
-            pass: 1
-    - delete:
-        ref:
-          apiVersion: kyverno.io/v1
-          kind: ClusterPolicy
-          name: remediate-restrict-automount-sa-token
-    - script: 
-        content: |
-          kubectl delete -f bad-resource.yaml
     - script:
         content: |
           sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' ../restrict-automount-sa-token.yaml | kubectl apply -f - 
@@ -46,4 +21,11 @@ spec:
         expect:
         - check:
             ($error != null): true
+        file: bad-resource.yaml
+    # After creating the remediate policy, we can create the bad resources as they will be mutated to become compliant
+    - apply:
+        file: ../remediate-restrict-automount-sa-token.yaml
+    - assert:
+        file: remediation-policy-assert.yaml
+    - apply:
         file: bad-resource.yaml

--- a/rbac-best-practices/restrict-automount-sa-token/e2e/chainsaw-test.yaml
+++ b/rbac-best-practices/restrict-automount-sa-token/e2e/chainsaw-test.yaml
@@ -3,6 +3,7 @@ kind: Test
 metadata:
   name: restrict-automount-sa-token-policy
 spec:
+  namespace: default
   steps:
   - name: test-restrict-automount-sa-token
     try:
@@ -10,6 +11,30 @@ spec:
         file: ../restrict-automount-sa-token.yaml
     - assert:
         file: policy-assert.yaml
+    - apply:
+        file: ../remediate-restrict-automount-sa-token.yaml
+    - assert:
+        file: remediation-policy-assert.yaml
+    - apply:
+        file: bad-resource.yaml
+    - sleep:
+        duration: 20s
+    - assert:
+        resource:
+          apiVersion: wgpolicyk8s.io/v1alpha2
+          kind: PolicyReport
+          summary:
+            error: 0
+            fail: 0
+            pass: 1
+    - delete:
+        ref:
+          apiVersion: kyverno.io/v1
+          kind: ClusterPolicy
+          name: remediate-restrict-automount-sa-token
+    - script: 
+        content: |
+          kubectl delete -f bad-resource.yaml
     - script:
         content: |
           sed 's/validationFailureAction: Audit/validationFailureAction: Enforce/' ../restrict-automount-sa-token.yaml | kubectl apply -f - 

--- a/rbac-best-practices/restrict-automount-sa-token/e2e/remediation-policy-assert.yaml
+++ b/rbac-best-practices/restrict-automount-sa-token/e2e/remediation-policy-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-automount-sa-token
+spec:
+  validationFailureAction: Audit
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/rbac-best-practices/restrict-automount-sa-token/remediate-restrict-automount-sa-token.yaml
+++ b/rbac-best-practices/restrict-automount-sa-token/remediate-restrict-automount-sa-token.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-automount-sa-token
+  annotations:
+    policies.kyverno.io/title: Remediate Restrict Auto-Mount of Service Account Tokens
+    policies.kyverno.io/category: RBAC Best Practices
+    policies.kyverno.io/description: >-
+      This policy remediates the restrict-automount-sa-token violation
+spec:
+  background: false
+  rules:
+    - name: remediate-restrict-automount-sa-token
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+      preconditions:
+        all:
+        - key: "{{ request.\"object\".metadata.labels.\"app.kubernetes.io/part-of\" || '' }}"
+          operator: NotEquals
+          value: policy-reporter
+      mutate:
+        patchStrategicMerge:
+          spec:
+            automountServiceAccountToken: false
+

--- a/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/bad-resource.yaml
+++ b/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/bad-resource.yaml
@@ -18,3 +18,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes/proxy"]
   verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: badcr03
+rules:
+- apiGroups: [""]
+  resources: ["nodes/proxy"]
+  verbs: ["get", "watch", "list"]

--- a/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/chainsaw-test.yaml
+++ b/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/chainsaw-test.yaml
@@ -22,3 +22,10 @@ spec:
         - check:
             ($error != null): true
         file: bad-resource.yaml
+    # After creating the remediate policy, we can create the bad resources as they will be mutated to become compliant
+    - apply:
+        file: ../remediate-restrict-clusterrole-nodesproxy.yaml
+    - assert:
+        file: remediation-policy-assert.yaml
+    - apply:
+        file: bad-resource.yaml

--- a/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/remediation-policy-assert.yaml
+++ b/rbac-best-practices/restrict-clusterrole-nodesproxy/e2e/remediation-policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-clusterrole-nodesproxy
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/rbac-best-practices/restrict-clusterrole-nodesproxy/remediate-restrict-clusterrole-nodesproxy.yaml
+++ b/rbac-best-practices/restrict-clusterrole-nodesproxy/remediate-restrict-clusterrole-nodesproxy.yaml
@@ -1,0 +1,34 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-clusterrole-nodesproxy
+  annotations:
+    policies.kyverno.io/title: Remediate Restrict ClusterRole with Nodes Proxy
+    policies.kyverno.io/category: RBAC Best Practices
+    policies.kyverno.io/description: >-
+      This policy remediates the restrict-clusterrole-nodesproxy violation
+spec:
+  background: false
+  rules:
+    - name: remediate-restrict-clusterrole-nodesproxy
+      match:
+        any:
+        - resources:
+            kinds:
+              - ClusterRole
+      mutate:
+        foreach: 
+          - list: request.object.rules[]
+            foreach:
+            - list: element.resources
+              preconditions:
+                all:
+                - key: "{{element}}"
+                  operator: Equals
+                  value: "nodes/proxy"
+              patchesJson6902: |-
+                - path: /rules/{{elementIndex0}}/resources/{{elementIndex1}}
+                  op: replace
+                  value: ""
+
+

--- a/rbac-best-practices/restrict-wildcard-resources/e2e/chainsaw-test.yaml
+++ b/rbac-best-practices/restrict-wildcard-resources/e2e/chainsaw-test.yaml
@@ -22,3 +22,10 @@ spec:
         - check:
             ($error != null): true
         file: bad-resource.yaml
+    # After creating the remediate policy, we can create the bad resources as they will be mutated to become compliant
+    - apply:
+        file: ../remediate-restrict-wildcard-resources.yaml
+    - assert:
+        file: remediation-policy-assert.yaml
+    - apply:
+        file: bad-resource.yaml

--- a/rbac-best-practices/restrict-wildcard-resources/e2e/remediation-policy-assert.yaml
+++ b/rbac-best-practices/restrict-wildcard-resources/e2e/remediation-policy-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-wildcard-resources
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/rbac-best-practices/restrict-wildcard-resources/remediate-restrict-wildcard-resources.yaml
+++ b/rbac-best-practices/restrict-wildcard-resources/remediate-restrict-wildcard-resources.yaml
@@ -1,0 +1,33 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: remediate-restrict-wildcard-resources
+  annotations:
+    policies.kyverno.io/title: Remediate Restrict Wildcard in Resources
+    policies.kyverno.io/category: RBAC Best Practices
+    policies.kyverno.io/description: >-
+      This policy remediates the restrict-wildcard-resources violation
+spec:
+  background: false
+  rules:
+    - name: remediate-restrict-wildcard-resources
+      match:
+        any:
+        - resources:
+            kinds:
+              - Role
+              - ClusterRole
+      mutate:
+        foreach: 
+          - list: request.object.rules[]
+            foreach:
+            - list: element.resources
+              preconditions:
+                all:
+                - key: "*"
+                  operator: Equals
+                  value: "{{element}}"
+              patchesJson6902: |-
+                - path: /rules/{{elementIndex0}}/resources/{{elementIndex1}}
+                  op: replace
+                  value: ""


### PR DESCRIPTION
**Description:**

This PR adds remediation policies for the following RBAC best practices policies:
- restrict-automount-sa-token
- restrict-clusterrole-nodesproxy
- restrict-wildcard-resources

In `remediate-restrict-clusterrole-nodesproxy` policy, we are replacing `nodes/proxy` with `""` instead of removing it. 
Consider we have a `ClusterRole` like this where the `resources` array contains a single element `nodes/proxy`
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: badcr03
rules:
- apiGroups: [""]
  resources: ["nodes/proxy"]
  verbs: ["get", "watch", "list"]
```
When we apply the remediate policy on this, it gets mutated to:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: badcr03
rules:
- apiGroups: [""]
  resources: [""]
  verbs: ["get", "watch", "list"]
```
If we had performed a `remove` operation on `nodes/proxy`, then creation of the `ClusterRole` would have been blocked by Kubernetes with the following error:
```bash
The ClusterRole "badcr03" is invalid: rules[0].resources: Required value: resource rules must supply at least one resource
``` 
An empty string `""` does not match any resources and can be considered a dummy value.

The above approach of replacing instead of removing has been followed in `remediate-restrict-wildcard-resources` policy too
<!-- Provide a brief description of your changes. -->

**Related Issues:**

<!-- List any related issues or tasks. -->

**Checklist:**
<!-- Add a `x` to mark the checkboxes as done. -->
- [ ] This PR requires a bump in kyverno-policies chart version .
- [ ] I have created a PR to bump the enterprise-kyverno-operator chart version.

