### PR TITLE
fix: update chainsaw tests violations messages

### DIFF
--- a/dockerfile-best-practices/check-apt-command-force-yes/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-apt-command-force-yes/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-apt-command-force-yes
                   error: ~
                   violations:
-                  - message: refrain from using the '--force-yes' option with `apt-get` as it bypasses important package validation checks and can potentially compromise the stability and security of your system.
+                  - message: refrain from using the '--force-yes' option with `apt-get` as it bypasses important package validation checks and can potentially compromise the stability and security of your system. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -87,7 +87,7 @@ spec:
                     name: check-apt-command-force-yes
                   error: ~
                   violations:
-                  - message: refrain from using the '--force-yes' option with `apt` as it bypasses important package validation checks and can potentially compromise the stability and security of your system.
+                  - message: refrain from using the '--force-yes' option with `apt` as it bypasses important package validation checks and can potentially compromise the stability and security of your system. (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-authentication/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-authentication/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: detect-unauthenticated-flag
                   error: ~
                   violations:
-                  - message: Dockerfile contains the '--allow-unauthenticated' which is not preferred
+                  - message: Dockerfile contains the '--allow-unauthenticated' which is not preferred (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-certificate-validation-curl/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-certificate-validation-curl/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-certificate-validation-curl
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by not using `--insecure` option
+                  - message: Ensure certificate validation is enabled by not using `--insecure` option (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-certificate-validation-nodejs-env-var/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-certificate-validation-nodejs-env-var/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-certificate-validation-nodejs-env-var
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by using `NODE_TLS_REJECT_UNAUTHORIZED` env with value set to `1`
+                  - message: Ensure certificate validation is enabled by using `NODE_TLS_REJECT_UNAUTHORIZED` env with value set to `1` (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/dockerfile-best-practices/check-certificate-validation-pip3/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-certificate-validation-pip3/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-certificate-validation-pip3
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by not using `--trusted-host` option with pip3
+                  - message: Ensure certificate validation is enabled by not using `--trusted-host` option with pip3 (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -86,7 +86,7 @@ spec:
                     name: check-certificate-validation-pip3
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by not using `--trusted-host` option with pip
+                  - message: Ensure certificate validation is enabled by not using `--trusted-host` option with pip (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-certificate-validation-python-env-var/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-certificate-validation-python-env-var/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-certificate-validation-python-env-var
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by using `PYTHONHTTPSVERIFY` env with value set to `1`
+                  - message: Ensure certificate validation is enabled by using `PYTHONHTTPSVERIFY` env with value set to `1` (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/dockerfile-best-practices/check-certificate-validation-wget/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-certificate-validation-wget/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-certificate-validation-wget
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by not using `--no-check-certificate` option
+                  - message: Ensure certificate validation is enabled by not using `--no-check-certificate` option (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-missing-signature-options/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-missing-signature-options/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-missing-signature-options
                   error: ~
                   violations:
-                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nodigest` flag
+                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nodigest` flag (CHECK=spec.rules[0].assert.all[3])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -86,7 +86,7 @@ spec:
                     name: check-missing-signature-options
                   error: ~
                   violations:
-                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nosignature` flag
+                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nosignature` flag (CHECK=spec.rules[0].assert.all[2])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -119,7 +119,7 @@ spec:
                     name: check-missing-signature-options
                   error: ~
                   violations:
-                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--noverify` flag
+                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--noverify` flag (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -152,7 +152,7 @@ spec:
                     name: check-missing-signature-options
                   error: ~
                   violations:
-                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nofiledigest` flag
+                  - message: Ensure that packages with untrusted or missing signatures are not used by rpm via `--nofiledigest` flag (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-nogpgcheck/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-nogpgcheck/test/chainsaw-test.yaml
@@ -109,7 +109,7 @@ spec:
                     name: check-nogpgcheck
                   error: ~
                   violations:
-                  - message: Enable GPG signature checking with yum by not using `--nogpgcheck` flag
+                  - message: Enable GPG signature checking with yum by not using `--nogpgcheck` flag (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -142,7 +142,7 @@ spec:
                     name: check-nogpgcheck
                   error: ~
                   violations:
-                  - message: Enable GPG signature checking with dnf by not using `--nogpgcheck` flag
+                  - message: Enable GPG signature checking with dnf by not using `--nogpgcheck` flag (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -175,7 +175,7 @@ spec:
                     name: check-nogpgcheck
                   error: ~
                   violations:
-                  - message: Enable GPG signature checking with tdnf by not using `--nogpgcheck` flag
+                  - message: Enable GPG signature checking with tdnf by not using `--nogpgcheck` flag (CHECK=spec.rules[0].assert.all[2])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/check-npm-config-strict-ssl/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-npm-config-strict-ssl/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-npm-config-strict-ssl
                   error: ~
                   violations:
-                  - message: Ensure certificate validation is enabled by setting `NODE_TLS_REJECT_UNAUTHORIZED` env with value set to `true`
+                  - message: Ensure certificate validation is enabled by setting `NODE_TLS_REJECT_UNAUTHORIZED` env with value set to `true` (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/dockerfile-best-practices/check-untrust-flag/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/check-untrust-flag/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: detect-untrusted-flag
                   error: ~
                   violations:
-                  - message: Dockerfile contains the '--allow-untrusted' which is not preferred
+                  - message: Dockerfile contains the '--allow-untrusted' which is not preferred (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/detect-multiple-instructions/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/detect-multiple-instructions/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: detect-multiple-instructions
                   error: ~
                   violations:
-                  - message: Found multiple instructions in a single line
+                  - message: Found multiple instructions in a single line (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/disallow-sudo-operations/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/disallow-sudo-operations/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: detect-sudo-operations
                   error: ~
                   violations:
-                  - message: Dockerfile contains the 'sudo' operation which is not preferred
+                  - message: Dockerfile contains the 'sudo' operation which is not preferred (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/prefer-copy-over-add/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/prefer-copy-over-add/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: prefer-copy-over-add
                   error: ~
                   violations:
-                  - message: Avoid the use of ADD instructions in Dockerfiles
+                  - message: Avoid the use of ADD instructions in Dockerfiles (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/dockerfile-best-practices/validate-healthcheck-instruction/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/validate-healthcheck-instruction/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: validate-healthcheck-instruction
                   error: ~
                   violations:
-                  - message: HEALTHCHECK instruction is not defined
+                  - message: HEALTHCHECK instruction is not defined (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/dockerfile-best-practices/validate-user-instruction/test/chainsaw-test.yaml
+++ b/dockerfile-best-practices/validate-user-instruction/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: validate-user-instruction
                   error: ~
                   violations:
-                  - message: USER instruction is not present in the Dockerfile
+                  - message: USER instruction is not present in the Dockerfile (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/config/ecs-best-practices/check-awsvpc-network-mode/test/chainsaw-test.yaml
+++ b/terraform/config/ecs-best-practices/check-awsvpc-network-mode/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-awsvpc-network-mode
                   error: ~
                   violations:
-                  - message: ECS services and tasks are required to use awsvpc network mode.
+                  - message: ECS services and tasks are required to use awsvpc network mode. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value != 'awsvpc'): true
@@ -86,7 +86,7 @@ spec:
                     name: check-awsvpc-network-mode
                   error: ~
                   violations:
-                  - message: ECS services and tasks are required to use awsvpc network mode.
+                  - message: ECS services and tasks are required to use awsvpc network mode. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value != 'awsvpc'): true

--- a/terraform/config/ecs-best-practices/validate-ecs-container-insights-enabled/test/chainsaw-test.yaml
+++ b/terraform/config/ecs-best-practices/validate-ecs-container-insights-enabled/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: validate-ecs-container-insights-enabled
                   error: ~
                   violations:
-                  - message: ECS container insights are not enabled
+                  - message: ECS container insights are not enabled (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueRequired
                       (value != 'enabled'): true

--- a/terraform/config/ecs-best-practices/validate-ecs-task-definition-pid-mode-check/test/chainsaw-test.yaml
+++ b/terraform/config/ecs-best-practices/validate-ecs-task-definition-pid-mode-check/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: validate-ecs-task-definition-pid-mode-check
                   error: ~
                   violations:
-                  - message: ECS task definitions shares the host's process namespace
+                  - message: ECS task definitions shares the host's process namespace (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value != 'task'): true

--- a/terraform/config/ecs-best-practices/validate-ecs-task-public-ip/test/chainsaw-test.yaml
+++ b/terraform/config/ecs-best-practices/validate-ecs-task-public-ip/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: validate-ecs-task-public-ip
                   error: ~
                   violations:
-                  - message: Public IP address should not be enabled
+                  - message: Public IP address should not be enabled (CHECK=spec.rules[0].assert.any[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/terraform/config/ecs-best-practices/validate-efs-volume-encryption/test/chainsaw-test.yaml
+++ b/terraform/config/ecs-best-practices/validate-efs-volume-encryption/test/chainsaw-test.yaml
@@ -107,7 +107,7 @@ spec:
                     name: validate-efs-volume-encryption
                   error: ~
                   violations:
-                  - message: "Transit Encryption is not `ENABLED` for EFS volumes in ECS Task definitions"
+                  - message: "Transit Encryption is not `ENABLED` for EFS volumes in ECS Task definitions (CHECK=spec.rules[0].assert.all[0])"
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -139,7 +139,7 @@ spec:
                     name: validate-efs-volume-encryption
                   error: ~
                   violations:
-                  - message: "Transit Encryption is not `ENABLED` for EFS volumes in ECS Task definitions"
+                  - message: "Transit Encryption is not `ENABLED` for EFS volumes in ECS Task definitions (CHECK=spec.rules[0].assert.all[0])"
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/config/s3-best-practices/abort-incomplete-uploads/test/chainsaw-test.yaml
+++ b/terraform/config/s3-best-practices/abort-incomplete-uploads/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: abort-incomplete-uploads
                   error: ~
                   violations:
-                  - message: Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block
+                  - message: Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: abort-incomplete-uploads
                   error: ~
                   violations:
-                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'
+                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled' (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: Disabled

--- a/terraform/config/s3-best-practices/disable-s3-acl/test/chainsaw-test.yaml
+++ b/terraform/config/s3-best-practices/disable-s3-acl/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: disable-s3-access-control-list
                   error: ~
                   violations:
-                  - message: Access Control List(ACL) should be disabled for an S3 Bucket
+                  - message: Access Control List(ACL) should be disabled for an S3 Bucket (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value=='BucketOwnerEnforced'): false

--- a/terraform/config/s3-best-practices/enable-aws-cloudtrail/test/chainsaw-test.yaml
+++ b/terraform/config/s3-best-practices/enable-aws-cloudtrail/test/chainsaw-test.yaml
@@ -79,7 +79,7 @@ spec:
                     name: check-aws-cloudtrail-logging
                   error: ~
                   violations:
-                  - message: Set the enable_logging argument in aws_cloudtrail resource to true
+                  - message: Set the enable_logging argument in aws_cloudtrail resource to true (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/config/s3-best-practices/enable-kms-encryption/test/chainsaw-test.yaml
+++ b/terraform/config/s3-best-practices/enable-kms-encryption/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: check-encryption-setting
                   error: ~
                   violations:
-                  - message: S3 server side encryption is not set to KMS
+                  - message: S3 server side encryption is not set to KMS (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: check-encryption-setting
                   error: ~
                   violations:
-                  - message: S3 server side encryption is not set to KMS
+                  - message: S3 server side encryption is not set to KMS (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/config/s3-best-practices/enable-lifecycle-configuration/test/chainsaw-test.yaml
+++ b/terraform/config/s3-best-practices/enable-lifecycle-configuration/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: check-s3-lifecycle-configuration
                   error: ~
                   violations:
-                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'
+                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled' (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: Disabled

--- a/terraform/plan/eks-best-practices/check-control-plane-logging/test/chainsaw-test.yaml
+++ b/terraform/plan/eks-best-practices/check-control-plane-logging/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-control-plane-logging
                   error: ~
                   violations:
-                  - message: EKS control plane logging must be enabled for all log types
+                  - message: EKS control plane logging must be enabled for all log types (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -86,7 +86,7 @@ spec:
                     name: check-control-plane-logging
                   error: ~
                   violations:
-                  - message: EKS control plane logging must be enabled for all log types
+                  - message: EKS control plane logging must be enabled for all log types (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/eks-best-practices/check-nodegroup-remote-access/test/chainsaw-test.yaml
+++ b/terraform/plan/eks-best-practices/check-nodegroup-remote-access/test/chainsaw-test.yaml
@@ -137,7 +137,7 @@ spec:
                   - message: >-
                       AWS EKS node group should not have implicit SSH access from 0.0.0.0/0
                       If `ec2_ssh_key` is specified and `source_security_group_ids` is not specified for the EKS Node Group, 
-                      either port 3389 for Windows or port 22 for other operating systems will be opened on the worker nodes to the Internet which can lead to unauthorized access
+                      either port 3389 for Windows or port 22 for other operating systems will be opened on the worker nodes to the Internet which can lead to unauthorized access (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -173,7 +173,7 @@ spec:
                   - message: >-
                       AWS EKS node group should not have implicit SSH access from 0.0.0.0/0
                       If `ec2_ssh_key` is specified and `source_security_group_ids` is not specified for the EKS Node Group, 
-                      either port 3389 for Windows or port 22 for other operating systems will be opened on the worker nodes to the Internet which can lead to unauthorized access
+                      either port 3389 for Windows or port 22 for other operating systems will be opened on the worker nodes to the Internet which can lead to unauthorized access (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/terraform/plan/eks-best-practices/check-public-endpoint/test/chainsaw-test.yaml
+++ b/terraform/plan/eks-best-practices/check-public-endpoint/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-public-endpoint
                   error: ~
                   violations:
-                  - message: Public access to EKS cluster endpoint must be explicitly set to false
+                  - message: Public access to EKS cluster endpoint must be explicitly set to false (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -86,7 +86,7 @@ spec:
                     name: check-public-endpoint
                   error: ~
                   violations:
-                  - message: Public access to EKS cluster endpoint must be explicitly set to false
+                  - message: Public access to EKS cluster endpoint must be explicitly set to false (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/terraform/plan/eks-best-practices/check-supported-k8s-version/test/chainsaw-test.yaml
+++ b/terraform/plan/eks-best-practices/check-supported-k8s-version/test/chainsaw-test.yaml
@@ -81,7 +81,7 @@ spec:
                     name: check-supported-k8s-version
                   error: ~
                   violations:
-                  - message: "Version specified must be one of these suppported versions ['1.23', '1.24', '1.25', '1.26', '1.27', '1.28', '1.29', '1.30']"
+                  - message: "Version specified must be one of these suppported versions ['1.23', '1.24', '1.25', '1.26', '1.27', '1.28', '1.29', '1.30'] (CHECK=spec.rules[0].assert.all[0])"
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/lambda-best-practices/check-env-var-encryption/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-env-var-encryption/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-env-var-encryption
                   error: ~
                   violations:
-                  - message: Enable the encryption of environment variable for the AWS Lambda function by specifying correct value to 'kms_key_arn' attribute in 'aws_lambda_function' resource block
+                  - message: Enable the encryption of environment variable for the AWS Lambda function by specifying correct value to 'kms_key_arn' attribute in 'aws_lambda_function' resource block (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value==''): false
@@ -86,7 +86,7 @@ spec:
                     name: check-env-var-encryption
                   error: ~
                   violations:
-                  - message: Enable the encryption of environment variable for the AWS Lambda function by specifying correct value to 'kms_key_arn' attribute in 'aws_lambda_function' resource block
+                  - message: Enable the encryption of environment variable for the AWS Lambda function by specifying correct value to 'kms_key_arn' attribute in 'aws_lambda_function' resource block (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value==''): false

--- a/terraform/plan/lambda-best-practices/check-function-concurrency/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-function-concurrency/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-function-concurrency
                   error: ~
                   violations:
-                  - message: Configure the AWS Lambda function for function-level concurrent execution limit using 'reserved_concurrent_execution' attribute
+                  - message: Configure the AWS Lambda function for function-level concurrent execution limit using 'reserved_concurrent_execution' attribute (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -86,7 +86,7 @@ spec:
                     name: check-function-concurrency
                   error: ~
                   violations:
-                  - message: Configure the AWS Lambda function for function-level concurrent execution limit using 'reserved_concurrent_execution' attribute
+                  - message: Configure the AWS Lambda function for function-level concurrent execution limit using 'reserved_concurrent_execution' attribute (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: null

--- a/terraform/plan/lambda-best-practices/check-lambda-code-signing/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-lambda-code-signing/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-lambda-code-signing
                   error: ~
                   violations:
-                  - message: Enable the code signing for the AWS Lambda function by specifying correct value to 'code_signing_config_arn' attribute in 'aws_lambda_function' resource block
+                  - message: Enable the code signing for the AWS Lambda function by specifying correct value to 'code_signing_config_arn' attribute in 'aws_lambda_function' resource block (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value==''): false

--- a/terraform/plan/lambda-best-practices/check-lambda-runtime/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-lambda-runtime/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-deprecated-runtime
                   error: ~
                   violations:
-                  - message: The runtime is deprecated for AWS lambda function, use the another version.
+                  - message: The runtime is deprecated for AWS lambda function, use the another version. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true

--- a/terraform/plan/lambda-best-practices/check-url-auth-type/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-url-auth-type/test/chainsaw-test.yaml
@@ -53,7 +53,7 @@ spec:
                     name: check-url-auth-type
                   error: ~
                   violations:
-                  - message: Set the authoriation type of the aws lambda function url is set to `AWS_IAM`
+                  - message: Set the authoriation type of the aws lambda function url is set to `AWS_IAM` (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/lambda-best-practices/check-x-ray-tracing-enabled/test/chainsaw-test.yaml
+++ b/terraform/plan/lambda-best-practices/check-x-ray-tracing-enabled/test/chainsaw-test.yaml
@@ -25,36 +25,35 @@ spec:
                     name: check-x-ray-tracing-enabled
                   error: ~
                   violations: ~
-# ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-# apiVersion: chainsaw.kyverno.io/v1alpha1
-# kind: Test
-# metadata:
-#   name: bad-test
-# spec:
-#   steps:
-#     - name: kyverno-json
-#       try:
-#       - script:
-#           content: |
-#             set -e
-#             kyverno-json scan --policy ../check-x-ray-tracing-enabled.yaml --payload ./bad-test/bad-payload.json --output json --bindings ./binding.yaml
-#           check:
-#             ($error): ~
-#             (json_parse($stdout)):
-#             - results:
-#               - policy:
-#                   apiVersion: json.kyverno.io/v1alpha1
-#                   kind: ValidatingPolicy
-#                   metadata:
-#                     name: enable-x-ray-tracing
-#                 rules:
-#                 - rule:
-#                     name: check-x-ray-tracing-enabled
-#                   error: ~
-#                   violations:
-#                   - message: Use the `tracing_config` block in the `aws_lambda_function` resource to set the mode to `Active` or `PassThrough`
-#                     errors:
-#                     - type: FieldValueInvalid
-#                       value: false
-#                       detail: 'Expected value: true'
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bad-test
+spec:
+  steps:
+    - name: kyverno-json
+      try:
+      - script:
+          content: |
+            set -e
+            kyverno-json scan --policy ../check-x-ray-tracing-enabled.yaml --payload ./bad-test/bad-payload.json --output json --bindings ./binding.yaml
+          check:
+            ($error): ~
+            (json_parse($stdout)):
+            - results:
+              - policy:
+                  apiVersion: json.kyverno.io/v1alpha1
+                  kind: ValidatingPolicy
+                  metadata:
+                    name: enable-x-ray-tracing
+                rules:
+                - rule:
+                    name: check-x-ray-tracing-enabled
+                  error: ~
+                  violations:
+                  - message: Use the `tracing_config` block in the `aws_lambda_function` resource to set the mode to `Active` or `PassThrough` (CHECK=spec.rules[0].assert.all[0])
+                    errors:
+                    - type: FieldValueInvalid
+                      value: false
+                      detail: 'Expected value: true'

--- a/terraform/plan/s3-best-practices/abort-incomplete-uploads/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/abort-incomplete-uploads/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: abort-incomplete-uploads
                   error: ~
                   violations:
-                  - message: Use the `aws_s3_bucket_lifecycle_configuration` resource to enable lifecycle configuration.
+                  - message: Use the `aws_s3_bucket_lifecycle_configuration` resource to enable lifecycle configuration. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: abort-incomplete-uploads
                   error: ~
                   violations:
-                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'
+                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled' (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -116,7 +116,7 @@ spec:
                     name: abort-incomplete-uploads
                   error: ~
                   violations:
-                  - message: Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block
+                  - message: Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block (CHECK=spec.rules[0].assert.all[2])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/disable-s3-acl/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/disable-s3-acl/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: disable-s3-access-control-list
                   error: ~
                   violations:
-                  - message: Access Control List(ACL) should be disabled for an S3 Bucket
+                  - message: Access Control List(ACL) should be disabled for an S3 Bucket (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       (value=='BucketOwnerEnforced'): false

--- a/terraform/plan/s3-best-practices/enable-aws-cloudtrail/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-aws-cloudtrail/test/chainsaw-test.yaml
@@ -79,7 +79,7 @@ spec:
                     name: check-aws-cloudtrail-logging
                   error: ~
                   violations:
-                  - message: Set the enable_logging argument in aws_cloudtrail resource to true
+                  - message: Set the enable_logging argument in aws_cloudtrail resource to true (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/enable-kms-encryption/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-kms-encryption/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: check-encryption-setting
                   error: ~
                   violations:
-                  - message: S3 server side encryption is not set to KMS
+                  - message: S3 server side encryption is not set to KMS (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: check-encryption-setting
                   error: ~
                   violations:
-                  - message: S3 server side encryption is not set to KMS
+                  - message: S3 server side encryption is not set to KMS (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -116,7 +116,7 @@ spec:
                     name: check-encryption-setting
                   error: ~
                   violations:
-                  - message: Use the `aws_s3_bucket_server_side_encryption_configuration ` resource to set the S3 server side encryption to KMS
+                  - message: Use the `aws_s3_bucket_server_side_encryption_configuration ` resource to set the S3 server side encryption to KMS (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/enable-lifecycle-configuration/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-lifecycle-configuration/test/chainsaw-test.yaml
@@ -29,6 +29,38 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: bad-test-01
+spec:
+  steps:
+    - name: kyverno-json
+      try:
+      - script:
+          content: |
+            set -e
+            kyverno-json scan --policy ../enable-lifecycle-configuration.yaml --payload ./bad-payload-01.json --output json --bindings ./binding.yaml
+          check:
+            ($error): ~
+            (json_parse($stdout)):
+            - results:
+              - policy:
+                  apiVersion: json.kyverno.io/v1alpha1
+                  kind: ValidatingPolicy
+                  metadata:
+                    name: s3-lifecycle-configuration
+                rules:
+                - rule:
+                    name: check-s3-lifecycle-configuration
+                  error: ~
+                  violations:
+                  - message: Use the `aws_s3_bucket_lifecycle_configuration` resource to enable lifecycle configuration. (CHECK=spec.rules[0].assert.all[0])
+                    errors:
+                    - type: FieldValueInvalid
+                      value: false
+                      detail: 'Expected value: true'
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: bad-test-02
 spec:
   steps:
@@ -52,7 +84,7 @@ spec:
                     name: check-s3-lifecycle-configuration
                   error: ~
                   violations:
-                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'
+                  - message: S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled' (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: check-s3-cross-region-replication
                   error: ~
                   violations:
-                  - message: Set S3 Bucket Cross Region Replication status to 'Enabled'
+                  - message: Set S3 Bucket Cross Region Replication status to 'Enabled' (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: check-s3-cross-region-replication
                   error: ~
                   violations:
-                  - message: Use the `aws_s3_bucket_replication_configuration` resource to set the status to Enabled
+                  - message: Use the `aws_s3_bucket_replication_configuration` resource to set the status to Enabled (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/enable-s3-server-access-logging/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-server-access-logging/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: enable-s3-server-access-logging
                   error: ~
                   violations:
-                  - message: Use the aws_s3_bucket_logging resource to enable server access logging
+                  - message: Use the aws_s3_bucket_logging resource to enable server access logging (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/enable-s3-versioning/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-versioning/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: check-s3-versioning-setting
                   error: ~
                   violations:
-                  - message: S3 Bucket Versioning needs to be set to 'Enabled'
+                  - message: S3 Bucket Versioning needs to be set to 'Enabled' (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -84,7 +84,7 @@ spec:
                     name: check-s3-versioning-setting
                   error: ~
                   violations:
-                  - message: Use the `aws_s3_bucket_versioning` resource to enable versioning.
+                  - message: Use the `aws_s3_bucket_versioning` resource to enable versioning. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/public-access-block/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/public-access-block/test/chainsaw-test.yaml
@@ -79,7 +79,7 @@ spec:
                     name: validate-block-s3-public-access-setting
                   error: ~
                   violations:
-                  - message: Block Public ACLs should be set to true
+                  - message: Block Public ACLs should be set to true (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -111,7 +111,7 @@ spec:
                     name: validate-block-s3-public-access-setting
                   error: ~
                   violations:
-                  - message: Block Public Policy should be set to true
+                  - message: Block Public Policy should be set to true (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -143,7 +143,7 @@ spec:
                     name: validate-block-s3-public-access-setting
                   error: ~
                   violations:
-                  - message: Ignore Public ACLs should be set to true
+                  - message: Ignore Public ACLs should be set to true (CHECK=spec.rules[0].assert.all[2])
                     errors:
                     - type: FieldValueInvalid
                       value: false
@@ -175,7 +175,7 @@ spec:
                     name: validate-block-s3-public-access-setting
                   error: ~
                   violations:
-                  - message: Restrict Public Buckets should be set to true
+                  - message: Restrict Public Buckets should be set to true (CHECK=spec.rules[0].assert.all[3])
                     errors:
                     - type: FieldValueInvalid
                       value: false

--- a/terraform/plan/s3-best-practices/validate-any-prinicpal/test/chainsaw-test.yaml
+++ b/terraform/plan/s3-best-practices/validate-any-prinicpal/test/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                     name: validate-any-principal
                   error: ~
                   violations:
-                  - message: Principal should not be set to `*` in the Bucket Policy.
+                  - message: Principal should not be set to `*` in the Bucket Policy. (CHECK=spec.rules[0].assert.all[0])
                     errors:
                     - type: FieldValueInvalid
                       value: true
@@ -84,7 +84,7 @@ spec:
                     name: validate-any-principal
                   error: ~
                   violations:
-                  - message: AWS should not be set to `*` in the Principal field for Bucket Policy
+                  - message: AWS should not be set to `*` in the Principal field for Bucket Policy (CHECK=spec.rules[0].assert.all[1])
                     errors:
                     - type: FieldValueInvalid
                       value: true


### PR DESCRIPTION
**Description:**
This PR updates the violations' messages in chainsaw tests. kyverno-json recently got an update that displays the path of failure in the output message. Therefore, we have to update chainsaw tests to accommodate these changes.

<!-- Provide a brief description of your changes. -->

**Related Issues:**

<!-- List any related issues or tasks. -->

**Checklist:**
<!-- Add a `x` to mark the checkboxes as done. -->
- [ ] This PR requires a bump in kyverno-policies chart version .
- [ ] I have created a PR to bump the enterprise-kyverno-operator chart version.

