### PR TITLE
NDEV-18111: add mutate policy for adding-capabilities-strict rule

### DIFF
--- a/pod-security/restricted/disallow-capabilities-strict/remediate-disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/remediate-disallow-capabilities-strict.yaml
@@ -29,9 +29,8 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities/drop
                 value:
-                  drop:
                   - ALL
           - list: request.object.spec.template.spec.initContainers[]
             order: Descending
@@ -42,9 +41,8 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities/drop
                 value:
-                  drop:
                   - ALL
           - list: request.object.spec.template.spec.ephemeralContainers[]
             order: Descending
@@ -55,10 +53,9 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities
-                value:
-                  drop:
-                  - ALL
+                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities/drop
+                value:  
+                - ALL
     - name: restrict-adding-capabilities-other-than-net-bind-service
       match:
         resources:
@@ -73,6 +70,9 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: AnyNotIn
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
@@ -84,11 +84,16 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: In
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
-              - op: replace
+              - op: remove
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities/add
+              - op: add
                 path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities/add
                 value:
                   - NET_BIND_RAW
@@ -97,6 +102,9 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: AnyNotIn
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
@@ -108,11 +116,16 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: In
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
-              - op: replace
+              - op: remove
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities/add
+              - op: add
                 path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities/add
                 value:
                   - NET_BIND_RAW
@@ -121,6 +134,9 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: AnyNotIn
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
@@ -132,11 +148,16 @@ spec:
             order: Descending
             preconditions:
               all:
+                - key: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+                  operator: NotEquals
+                  value: []
                 - key: NET_BIND_RAW
                   operator: In
                   value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
-              - op: replace
+              - op: remove
+                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities/add
+              - op: add
                 path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities/add
                 value:
                   - NET_BIND_RAW

--- a/pod-security/restricted/disallow-capabilities-strict/remediate-disallow-capabilities-strict.yaml
+++ b/pod-security/restricted/disallow-capabilities-strict/remediate-disallow-capabilities-strict.yaml
@@ -29,11 +29,10 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/containers/{{elementIndex}}/securityContext
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities
                 value:
-                  capabilities:
-                    drop:
-                      - ALL
+                  drop:
+                  - ALL
           - list: request.object.spec.template.spec.initContainers[]
             order: Descending
             preconditions:
@@ -43,11 +42,10 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities
                 value:
-                  capabilities:
-                    drop:
-                      - ALL
+                  drop:
+                  - ALL
           - list: request.object.spec.template.spec.ephemeralContainers[]
             order: Descending
             preconditions:
@@ -57,8 +55,88 @@ spec:
                   value: "{{ element.securityContext.capabilities.drop[].to_upper(@) || `[]` }}"
             patchesJson6902: |-
               - op: add
-                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext
+                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities
                 value:
-                  capabilities:
-                    drop:
-                      - ALL
+                  drop:
+                  - ALL
+    - name: restrict-adding-capabilities-other-than-net-bind-service
+      match:
+        resources:
+          kinds:
+            - Deployment
+            - StatefulSet
+            - Job
+            - DaemonSet
+      mutate:
+        foreach:
+          - list: request.object.spec.template.spec.containers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: AnyNotIn
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: remove
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities/add
+          
+          - list: request.object.spec.template.spec.containers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: In
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: replace
+                path: /spec/template/spec/containers/{{elementIndex}}/securityContext/capabilities/add
+                value:
+                  - NET_BIND_RAW
+          
+          - list: request.object.spec.template.spec.initContainers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: AnyNotIn
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: remove
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities/add
+          
+          - list: request.object.spec.template.spec.initContainers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: In
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: replace
+                path: /spec/template/spec/initContainers/{{elementIndex}}/securityContext/capabilities/add
+                value:
+                  - NET_BIND_RAW
+          
+          - list: request.object.spec.template.spec.ephemeralContainers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: AnyNotIn
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: remove
+                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities/add
+          
+          - list: request.object.spec.template.spec.ephemeralContainers[]
+            order: Descending
+            preconditions:
+              all:
+                - key: NET_BIND_RAW
+                  operator: In
+                  value: "{{ element.securityContext.capabilities.add[].to_upper(@) || `[]` }}"
+            patchesJson6902: |-
+              - op: replace
+                path: /spec/template/spec/ephemeralContainers/{{elementIndex}}/securityContext/capabilities/add
+                value:
+                  - NET_BIND_RAW


### PR DESCRIPTION
**Description:**
## Final Changes:
Replace is not supported in kyverno1.10. So, used a combination of `remove and add.`

Add a rule to restrict-adding-capabilities-other-than-net-bind-service.  

> The patchesJson6902 method can be useful when a specific mutation is needed which cannot be performed by patchesStrategicMerge. For example, when needing to mutate a specific object within an array, the index can be specified as part of a patchesJson6902 mutation rule.
> 
> One distinction between this and other mutation methods is that patchesJson6902 does not support the use of conditional anchors. Use [preconditions](https://kyverno.io/docs/writing-policies/preconditions/) instead. Also, mutations using patchesJson6902 to Pods directly are not converted to higher-level controllers such as Deployments and StatefulSets through the use of the [auto-gen feature](https://kyverno.io/docs/writing-policies/autogen/). Therefore, when writing such mutation rules for Pods, it may be necessary to create multiple rules to cover all relevant Pod controllers.
> 

Since we cannot use conditional anchors had to use two pre conditions. 


* Previously, the existing rule for drop all capabilities was clearing all entries in securityContext. Fixed it  
<img width="1388" alt="Screenshot 2024-09-29 at 11 38 02 AM" src="https://github.com/user-attachments/assets/feaa083f-a8fd-49e6-a53d-c0fcc414558b">


