### PR TITLE
Updated the released kyverno version for chainsaw actions

### DIFF
--- a/.github/workflows/chainsaw-e2e.yaml
+++ b/.github/workflows/chainsaw-e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false    
       matrix:
         k8s-version: [v1.30.0, v1.29.4, v1.28.9]
-        n4k-chart-version: [3.0.31]
+        n4k-chart-version: [3.0.33]    # nirmata kyverno chart version for 1.10.n4k
 
     steps:
       - name: Checkout
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false    
       matrix:
         k8s-version: [v1.30.0, v1.29.4, v1.28.9]
-        n4k-chart-version: [3.1.18, 3.2.2]
+        n4k-chart-version: [3.1.21, 3.2.4] # nirmata kyverno chart version for 1.11 and 1.12 n4k
 
     steps:
       - name: Checkout
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false    
       matrix:
         k8s-version: [v1.27.3, v1.26.3]
-        n4k-chart-version: [3.1.18, 3.2.2]
+        n4k-chart-version: [3.1.21, 3.2.4] # nirmata kyverno chart version for 1.11 and 1.12 n4k
 
     steps:
       - name: Checkout
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false    
       matrix:
         k8s-version: [v1.30.0, v1.29.4, v1.28.9]
-        n4k-chart-version: [3.1.18, 3.2.2]
+        n4k-chart-version: [3.1.21, 3.2.4] # nirmata kyverno chart version for 1.11 and 1.12 n4k
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description:**

- Updated the chainsaw test GitHub action by changing the nirmata kyverno release chart version. In kyverno Policies repo we were testing the policies against the released versions only.  
