### PR TITLE
replace bases with resources

### DIFF
--- a/pod-security/baseline/kustomization.yaml
+++ b/pod-security/baseline/kustomization.yaml
@@ -1,13 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - disallow-capabilities/disallow-capabilities.yaml
-  - disallow-host-namespaces/disallow-host-namespaces.yaml
-  - disallow-host-path/disallow-host-path.yaml
-  - disallow-host-ports/disallow-host-ports.yaml
-  - disallow-host-process/disallow-host-process.yaml
-  - disallow-privileged-containers/disallow-privileged-containers.yaml
-  - disallow-proc-mount/disallow-proc-mount.yaml
-  - disallow-selinux/disallow-selinux.yaml
-  - restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
-  - restrict-seccomp/restrict-seccomp.yaml
-  - restrict-sysctls/restrict-sysctls.yaml
-  
+- disallow-capabilities/disallow-capabilities.yaml
+- disallow-host-namespaces/disallow-host-namespaces.yaml
+- disallow-host-path/disallow-host-path.yaml
+- disallow-host-ports/disallow-host-ports.yaml
+- disallow-host-process/disallow-host-process.yaml
+- disallow-privileged-containers/disallow-privileged-containers.yaml
+- disallow-proc-mount/disallow-proc-mount.yaml
+- disallow-selinux/disallow-selinux.yaml
+- restrict-apparmor-profiles/restrict-apparmor-profiles.yaml
+- restrict-seccomp/restrict-seccomp.yaml
+- restrict-sysctls/restrict-sysctls.yaml
+

--- a/pod-security/enforce/kustomization.yaml
+++ b/pod-security/enforce/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../restricted
 
 patches:

--- a/pod-security/enforce/kustomization.yaml
+++ b/pod-security/enforce/kustomization.yaml
@@ -1,10 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - ../restricted
 
 patches:
-  - patch: |-
-      - op: replace
-        path: /spec/validationFailureAction
-        value: enforce
-    target:
-      kind: ClusterPolicy
+- patch: |-
+    - op: replace
+      path: /spec/validationFailureAction
+      value: Enforce
+  target:
+    kind: ClusterPolicy
+

--- a/pod-security/kustomization.yaml
+++ b/pod-security/kustomization.yaml
@@ -1,2 +1,2 @@
-bases:
+resources:
 - restricted

--- a/pod-security/kustomization.yaml
+++ b/pod-security/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - restricted

--- a/pod-security/restricted/kustomization.yaml
+++ b/pod-security/restricted/kustomization.yaml
@@ -1,10 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../baseline
-  
-resources:
-  - disallow-capabilities-strict/disallow-capabilities-strict.yaml
-  - disallow-privilege-escalation/disallow-privilege-escalation.yaml
-  - require-run-as-non-root-user/require-run-as-non-root-user.yaml
-  - require-run-as-nonroot/require-run-as-nonroot.yaml
-  - restrict-seccomp-strict/restrict-seccomp-strict.yaml
-  - restrict-volume-types/restrict-volume-types.yaml
+- ../baseline
+- disallow-capabilities-strict/disallow-capabilities-strict.yaml
+- disallow-privilege-escalation/disallow-privilege-escalation.yaml
+- require-run-as-non-root-user/require-run-as-non-root-user.yaml
+- require-run-as-nonroot/require-run-as-nonroot.yaml
+- restrict-seccomp-strict/restrict-seccomp-strict.yaml
+- restrict-volume-types/restrict-volume-types.yaml
+
+

--- a/pod-security/restricted/kustomization.yaml
+++ b/pod-security/restricted/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
   - ../baseline
   
 resources:


### PR DESCRIPTION
**Description:**

Running Kustomize on current repo gives this error:

```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```

**Related Issues:**

Fixes https://nirmata.atlassian.net/browse/NDEV-22542

**Checklist:**
<!-- Add a `x` to mark the checkboxes as done. -->
- [] This PR requires a bump in kyverno-policies chart version .
- [] I have created a PR to bump the enterprise-kyverno-operator chart version.

