### PR TITLE
Add policies for GH actions

### DIFF
--- a/github-actions/fixtures/bad/always-true-condition.yml
+++ b/github-actions/fixtures/bad/always-true-condition.yml
@@ -1,0 +1,25 @@
+# always-true-condition.yml — triggers no-always-true-condition
+# if: true is almost always a mistake. A security-gate step with this condition
+# provides no protection and always executes regardless of context.
+name: Always True Condition
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: always-true condition — security gate provides no protection
+      - name: Conditional step
+        if: true
+        run: echo "this always runs"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/curl-pipe-bash.yml
+++ b/github-actions/fixtures/bad/curl-pipe-bash.yml
@@ -1,0 +1,24 @@
+# curl-pipe-bash.yml — triggers no-curl-pipe-bash
+# Piping curl directly to bash executes arbitrary remote code with no
+# integrity check. A compromised server or MITM can serve a malicious payload.
+name: Curl Pipe Bash
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: fetches and executes arbitrary remote code without verification
+      - name: Install tool
+        run: curl -sSfL https://example.com/install.sh | bash
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/debug-action.yml
+++ b/github-actions/fixtures/bad/debug-action.yml
@@ -1,0 +1,24 @@
+# debug-action.yml — triggers no-debug-actions
+# action-tmate opens an interactive SSH session on the runner, giving anyone
+# with the session URL full shell access and access to all secrets.
+name: Debug Action
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: opens SSH shell on the runner
+      - name: Debug session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 30

--- a/github-actions/fixtures/bad/debug-enabled.yml
+++ b/github-actions/fixtures/bad/debug-enabled.yml
@@ -1,0 +1,27 @@
+# debug-enabled.yml — triggers no-debug-enabled
+# ACTIONS_STEP_DEBUG causes GitHub Actions to print all environment variables,
+# including injected secrets, to the workflow log in plain text.
+name: Debug Enabled
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+# VIOLATION: exposes all env vars (including secrets) in workflow logs
+env:
+  ACTIONS_STEP_DEBUG: 'true'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build
+        run: make build
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/excessive-job-permissions.yml
+++ b/github-actions/fixtures/bad/excessive-job-permissions.yml
@@ -1,0 +1,30 @@
+# excessive-job-permissions.yml — triggers no-excessive-job-permissions
+# This job requests id-token: write for OIDC cloud auth AND contents: write
+# for pushing to the repo. Combining OIDC with broad write permissions in a
+# single job unnecessarily widens the blast radius.
+name: Excessive Job Permissions
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # VIOLATION: id-token: write combined with contents: write
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Authenticate to cloud
+        run: echo "Authenticating..."
+        timeout-minutes: 5
+
+      - name: Push release notes
+        run: git push origin main
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/github-env-injection.yml
+++ b/github-actions/fixtures/bad/github-env-injection.yml
@@ -1,0 +1,25 @@
+# github-env-injection.yml — triggers no-github-env-injection
+# Writing an attacker-controlled PR title to $GITHUB_ENV persists the
+# untrusted value into the environment for all subsequent steps.
+name: GitHub ENV Injection
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Expose PR title
+        # VIOLATION: attacker-controlled PR title written to GITHUB_ENV
+        run: echo "PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+        timeout-minutes: 5
+
+      - name: Use title
+        run: echo "Building $PR_TITLE"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/github-path-injection.yml
+++ b/github-actions/fixtures/bad/github-path-injection.yml
@@ -1,0 +1,24 @@
+# github-path-injection.yml — triggers no-github-path-injection
+# Writing attacker-controlled input to $GITHUB_PATH allows prepending
+# arbitrary directories to PATH, enabling binary shadowing attacks.
+name: GITHUB_PATH Injection
+
+on:
+  workflow_dispatch:
+    inputs:
+      tool_path:
+        description: Path to tool directory
+        required: true
+
+permissions: read-all
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Add tool to PATH
+        # VIOLATION: caller-controlled input written to GITHUB_PATH
+        run: echo "${{ github.event.inputs.tool_path }}" >> $GITHUB_PATH
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/github-script-injection.yml
+++ b/github-actions/fixtures/bad/github-script-injection.yml
@@ -1,0 +1,28 @@
+# github-script-injection.yml — triggers no-github-script-injection
+# Interpolating attacker-controlled context expressions directly in the
+# script: parameter of actions/github-script allows arbitrary JS injection.
+name: GitHub Script Injection
+
+on:
+  issues:
+    types: [opened]
+
+permissions: read-all
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          # VIOLATION: PR title (attacker-controlled) interpolated in script
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['${{ github.event.issue.title }}']
+            })

--- a/github-actions/fixtures/bad/hardcoded-credentials.yml
+++ b/github-actions/fixtures/bad/hardcoded-credentials.yml
@@ -1,0 +1,26 @@
+# hardcoded-credentials.yml — triggers no-hardcoded-container-credentials
+# A literal credential value in a step env block is stored in source control
+# and visible to anyone with repository read access.
+name: Hardcoded Credentials
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: literal credential — use ${{ secrets.DOCKER_PASSWORD }} instead
+      - name: Login to Docker Hub
+        run: echo "$DOCKER_PASSWORD" | docker login -u myuser --password-stdin
+        env:
+          DOCKER_PASSWORD: supersecretpassword123
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/head-ref-in-action-input.yml
+++ b/github-actions/fixtures/bad/head-ref-in-action-input.yml
@@ -1,0 +1,30 @@
+# head-ref-in-action-input.yml — triggers no-pr-head-ref-in-action-input
+# Passing github.head_ref (an attacker-controlled branch name) directly in
+# the with: params of an action step. Branch names can contain shell
+# metacharacters that may be interpreted unsafely inside the action.
+name: Head Ref in Action Input
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: read-all
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment with branch name
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          # VIOLATION: attacker-controlled head_ref passed directly as action input
+          branch: ${{ github.head_ref }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Branch: ${process.env.BRANCH}`
+            })

--- a/github-actions/fixtures/bad/impostor-commit.yml
+++ b/github-actions/fixtures/bad/impostor-commit.yml
@@ -1,0 +1,26 @@
+# impostor-commit.yml — triggers impostor-commit
+# The pinned SHA (v4.1.0's commit) does not match what the v4.2.2 tag
+# resolves to on GitHub. This simulates a scenario where a tag has been
+# silently moved to point to different code than originally intended.
+name: Impostor Commit
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        # VIOLATION: SHA is from v4.1.0 but comment claims v4.2.2 — tag mismatch
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608  # v4.2.2
+        timeout-minutes: 5
+
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/job-debug-env.yml
+++ b/github-actions/fixtures/bad/job-debug-env.yml
@@ -1,0 +1,23 @@
+# job-debug-env.yml — triggers no-job-debug-env
+# ACTIONS_STEP_DEBUG in a job-level env block causes GitHub Actions to print
+# all environment variables and runner diagnostics to the log, including secrets.
+name: Debug Env Enabled
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # VIOLATION: dumps all env vars (including secrets) to the workflow log
+    env:
+      ACTIONS_STEP_DEBUG: "true"
+    steps:
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/job-env-injection.yml
+++ b/github-actions/fixtures/bad/job-env-injection.yml
@@ -1,0 +1,23 @@
+# job-env-injection.yml — triggers no-job-env-injection
+# Setting attacker-controlled context expressions in a job-level env block
+# propagates untrusted data to every step in the job.
+name: Job Env Injection
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # VIOLATION: attacker-controlled PR title set at job level env
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/job-unsecure-commands.yml
+++ b/github-actions/fixtures/bad/job-unsecure-commands.yml
@@ -1,0 +1,23 @@
+# job-unsecure-commands.yml — triggers no-job-unsecure-commands
+# ACTIONS_ALLOW_UNSECURE_COMMANDS in a job-level env block re-enables the
+# deprecated ::set-env and ::add-path workflow commands for all steps.
+name: Unsecure Commands Enabled
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # VIOLATION: re-enables deprecated ::set-env and ::add-path commands
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    steps:
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/known-vulnerable-action.yml
+++ b/github-actions/fixtures/bad/known-vulnerable-action.yml
@@ -1,0 +1,24 @@
+# known-vulnerable-action.yml — triggers known-vulnerable-actions
+# Uses reviewdog/action-setup@v1 which is recorded in OSV.dev as
+# GHSA-qmg3-hpqr-gqvc (supply-chain compromise, March 2025).
+name: Known Vulnerable Action
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup reviewdog
+        # VIOLATION: reviewdog/action-setup@v1 is a known-compromised version
+        uses: reviewdog/action-setup@f0d342d24037bb11d26b9bd8496e0808ba32e9ec  # v1
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/no-permissions.yml
+++ b/github-actions/fixtures/bad/no-permissions.yml
@@ -1,0 +1,21 @@
+# no-permissions.yml — triggers Policy 3 (require-permissions-block)
+# Workflow has no top-level permissions block, so GITHUB_TOKEN inherits
+# repository defaults which may grant write access to all scopes.
+name: No Permissions
+
+on:
+  push:
+    branches: [main]
+
+# VIOLATION: no permissions block — GITHUB_TOKEN uses repository defaults
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build
+        run: make build
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/no-step-timeout.yml
+++ b/github-actions/fixtures/bad/no-step-timeout.yml
@@ -1,0 +1,23 @@
+# no-step-timeout.yml — triggers steps-have-timeout
+# A run step without timeout-minutes can hang indefinitely, consuming
+# all available runner minutes.
+name: No Step Timeout
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build
+        # VIOLATION: run step with no timeout-minutes
+        run: make build

--- a/github-actions/fixtures/bad/prt-checkout.yml
+++ b/github-actions/fixtures/bad/prt-checkout.yml
@@ -1,0 +1,24 @@
+# prt-checkout.yml — triggers Policy 1 (pull-request-target-with-checkout)
+# A privileged pull_request_target workflow checks out the PR contributor's ref,
+# giving untrusted code access to secrets and write permissions.
+name: PWN Request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # VIOLATION: actions/checkout with PR head ref inside pull_request_target
+      - name: Checkout PR code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/release-without-concurrency.yml
+++ b/github-actions/fixtures/bad/release-without-concurrency.yml
@@ -1,0 +1,25 @@
+# release-without-concurrency.yml — triggers require-concurrency-on-release
+# A release workflow without a concurrency group can run simultaneously if
+# two releases are published in quick succession, corrupting artifacts.
+name: Release
+
+on:
+  release:
+    types: [published]
+
+# VIOLATION: no concurrency block — two simultaneous releases can corrupt artifacts
+
+permissions: read-all
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Publish
+        run: make publish
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/reusable-workflow-secrets-inherit.yml
+++ b/github-actions/fixtures/bad/reusable-workflow-secrets-inherit.yml
@@ -1,0 +1,16 @@
+# reusable-workflow-secrets-inherit.yml — triggers no-reusable-workflow-secrets-inherit
+# secrets: inherit forwards every caller secret to the callee. If the callee
+# is a third-party workflow or is later compromised, all secrets are exposed.
+name: Reusable Workflow Secrets Inherit
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  call:
+    # VIOLATION: secrets: inherit forwards all caller secrets to the callee
+    uses: some-org/some-repo/.github/workflows/ci.yml@11bd71901bbe5b1630ceea73d27597364c9af683
+    secrets: inherit

--- a/github-actions/fixtures/bad/script-injection.yml
+++ b/github-actions/fixtures/bad/script-injection.yml
@@ -1,0 +1,30 @@
+# script-injection.yml — triggers Policy 4 (no-script-injection)
+# An attacker controlling a PR title or branch name can inject arbitrary
+# shell commands via the ${{ github.event.pull_request.* }} context expression.
+name: Script Injection
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        timeout-minutes: 5
+
+      # VIOLATION: PR title is attacker-controlled and interpolated directly into shell
+      - name: Echo PR title
+        run: echo "PR title is ${{ github.event.pull_request.title }}"
+        timeout-minutes: 5
+
+      # VIOLATION: head_ref (branch name) is attacker-controlled
+      - name: Check branch
+        run: echo "Branch is ${{ github.head_ref }}"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/secrets-in-github-env.yml
+++ b/github-actions/fixtures/bad/secrets-in-github-env.yml
@@ -1,0 +1,28 @@
+# secrets-in-github-env.yml — triggers no-secrets-in-github-env
+# Writing a secret to $GITHUB_ENV exposes it to all subsequent steps in
+# the job, including any that log the environment or pass it externally.
+name: Secrets In GITHUB_ENV
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: persists secret into the job environment for all subsequent steps
+      - name: Export token
+        run: echo "TOKEN=${{ secrets.MY_TOKEN }}" >> $GITHUB_ENV
+        timeout-minutes: 5
+
+      - name: Use token
+        run: make deploy
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/secrets-in-workflow-env.yml
+++ b/github-actions/fixtures/bad/secrets-in-workflow-env.yml
@@ -1,0 +1,23 @@
+# secrets-in-workflow-env.yml — triggers no-secrets-in-workflow-env
+# Secrets in workflow-level env are accessible to all jobs, including
+# fork PR runs that execute attacker-controlled code.
+name: Secrets in Workflow Env
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+# VIOLATION: secret reference at workflow level, visible to all jobs
+env:
+  MY_TOKEN: ${{ secrets.MY_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/github-actions/fixtures/bad/self-hosted.yml
+++ b/github-actions/fixtures/bad/self-hosted.yml
@@ -1,0 +1,20 @@
+# self-hosted.yml — triggers no-self-hosted-runners
+# Self-hosted runners on public repos let any contributor execute code
+# on your infrastructure.
+name: Self-Hosted CI
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    # VIOLATION: self-hosted runner
+    runs-on: [self-hosted, linux, x64]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/github-actions/fixtures/bad/tojson-secrets.yml
+++ b/github-actions/fixtures/bad/tojson-secrets.yml
@@ -1,0 +1,24 @@
+# toJson-secrets.yml — triggers no-toJson-secrets
+# Serialising all secrets with toJson(secrets) leaks every secret available
+# to the workflow in a single value that can be logged or exfiltrated.
+name: ToJson Secrets
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: dumps every secret as a JSON blob
+      - name: Debug all secrets
+        run: echo "${{ toJson(secrets) }}"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/unguarded-comment-trigger.yml
+++ b/github-actions/fixtures/bad/unguarded-comment-trigger.yml
@@ -1,0 +1,24 @@
+# unguarded-comment-trigger.yml — triggers no-unguarded-comment-trigger
+# Any user posting a comment can trigger this workflow, which runs with
+# access to repository secrets and write permissions via GITHUB_TOKEN.
+name: Comment Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: no author_association check — any commenter triggers this
+      - name: Run command
+        run: echo "Running command from comment"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/unguarded-workflow-run.yml
+++ b/github-actions/fixtures/bad/unguarded-workflow-run.yml
@@ -1,0 +1,27 @@
+# unguarded-workflow-run.yml — triggers no-unguarded-comment-trigger/workflow-run-trigger-requires-fork-check
+# The workflow_run trigger runs with base-repository secrets and permissions but
+# can be initiated by a fork PR's workflow. Without checking
+# github.event.workflow_run.head_repository.fork, artifacts from an untrusted
+# fork can influence privileged execution.
+name: Post-CI
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions: read-all
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # VIOLATION: no check on github.event.workflow_run.head_repository.fork
+      - name: Process results
+        run: echo "Processing workflow results"
+        timeout-minutes: 5

--- a/github-actions/fixtures/bad/unjustified-write-permissions.yml
+++ b/github-actions/fixtures/bad/unjustified-write-permissions.yml
@@ -1,0 +1,26 @@
+# unjustified-write-permissions.yml — triggers no-unjustified-write-permissions
+# The job grants packages: write but no step uses an action that requires it.
+# All steps use known actions (actions/checkout only needs contents: read),
+# so the policy can safely flag the unjustified write permission.
+name: Unjustified Write Permissions
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # VIOLATION: no step in this job needs packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        timeout-minutes: 5
+
+      - name: Build
+        run: make build
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/unpinned-actions.yml
+++ b/github-actions/fixtures/bad/unpinned-actions.yml
@@ -1,0 +1,29 @@
+# unpinned-actions.yml — triggers Policy 2 (require-pinned-actions)
+# Actions are referenced by mutable tags (@v4, @main) rather than full commit SHAs.
+name: Unpinned Actions
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # VIOLATION: @v4 is a mutable tag — can be repointed to malicious code
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # VIOLATION: @v5 is a mutable tag
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Build
+        run: make build
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/unpinned-container.yml
+++ b/github-actions/fixtures/bad/unpinned-container.yml
@@ -1,0 +1,23 @@
+# unpinned-container.yml — triggers require-pinned-containers
+# A mutable container tag is vulnerable to image substitution. A registry
+# compromise or stale cache can silently change what runs in the job.
+name: Unpinned Container
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # VIOLATION: mutable tag — use image@sha256:<digest> instead
+    container:
+      image: ubuntu:latest
+    permissions:
+      contents: read
+    steps:
+      - name: Build
+        run: make build
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/unpinned-reusable-workflow.yml
+++ b/github-actions/fixtures/bad/unpinned-reusable-workflow.yml
@@ -1,0 +1,15 @@
+# unpinned-reusable-workflow.yml — triggers require-pinned-actions/reusable-workflows-pinned-to-sha
+# Job-level uses: with a mutable tag is vulnerable to the same tag-mutation
+# supply chain attack as unpinned step actions.
+name: Unpinned Reusable Workflow
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  call:
+    # VIOLATION: mutable ref @main — use a full 40-char SHA instead
+    uses: some-org/some-repo/.github/workflows/ci.yml@main

--- a/github-actions/fixtures/bad/unsecure-commands.yml
+++ b/github-actions/fixtures/bad/unsecure-commands.yml
@@ -1,0 +1,28 @@
+# unsecure-commands.yml — triggers no-unsecure-commands
+# ACTIONS_ALLOW_UNSECURE_COMMANDS re-enables the deprecated ::set-env and
+# ::add-path workflow commands. Any log output can then inject into environment
+# variables and PATH, enabling code execution via influenced log lines.
+name: Unsecure Commands
+
+on:
+  push:
+    branches: [main]
+
+permissions: read-all
+
+# VIOLATION: re-enables deprecated injection vector for all jobs
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build
+        run: make build
+        timeout-minutes: 20

--- a/github-actions/fixtures/bad/untrusted-env-vars.yml
+++ b/github-actions/fixtures/bad/untrusted-env-vars.yml
@@ -1,0 +1,30 @@
+# untrusted-env-vars.yml — triggers no-untrusted-env-vars
+# The workflow-level env block contains github.head_ref, which is controlled
+# by the PR author. If any downstream step uses BRANCH_NAME in an unquoted
+# shell context, an attacker can inject arbitrary commands via the branch name.
+name: Env Injection
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+# VIOLATION: attacker-controlled value set at workflow scope
+env:
+  BRANCH_NAME: ${{ github.head_ref }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build
+        run: echo "Building branch $BRANCH_NAME"
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/workflow-dispatch-injection.yml
+++ b/github-actions/fixtures/bad/workflow-dispatch-injection.yml
@@ -1,0 +1,24 @@
+# workflow-dispatch-injection.yml — triggers no-workflow-dispatch-injection
+# Interpolating workflow_dispatch inputs directly in run steps allows
+# callers to inject arbitrary shell commands.
+name: Dispatch Injection
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Deploy target
+        required: true
+
+permissions: read-all
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Deploy
+        # VIOLATION: caller-controlled input interpolated directly in shell
+        run: ./deploy.sh ${{ github.event.inputs.target }}
+        timeout-minutes: 10

--- a/github-actions/fixtures/bad/write-all-permissions.yml
+++ b/github-actions/fixtures/bad/write-all-permissions.yml
@@ -1,0 +1,18 @@
+# write-all-permissions.yml — triggers no-write-all-permissions
+# permissions: write-all grants the GITHUB_TOKEN write access to every
+# repository scope, equivalent to admin access during the workflow run.
+name: Write-All Permissions
+
+on:
+  push:
+    branches: [main]
+
+# VIOLATION: write-all grants unrestricted token access
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/github-actions/fixtures/good/secure-workflow.yml
+++ b/github-actions/fixtures/good/secure-workflow.yml
@@ -1,0 +1,44 @@
+# secure-workflow.yml — passes all built-in policies
+name: Secure CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Policy 3 + 7: explicit permissions block, not write-all
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Policy 6: no self-hosted
+
+    # Policy 3: job permissions not write-all
+    permissions:
+      contents: read
+
+    steps:
+      # Policy 2: pinned to full SHA
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # Policy 2: pinned to full SHA
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
+        with:
+          go-version: "1.22"
+
+      # Policy 4: no untrusted context in run; Policy 8: has timeout-minutes
+      - name: Build
+        run: make build
+        timeout-minutes: 20
+
+      # Policy 4: safe use of env var instead of direct context expression
+      # Policy 8: has timeout-minutes
+      - name: Test
+        env:
+          # Policy 5: no ${{ secrets.* }} at workflow level; secrets are scoped to this step
+          TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
+        run: make test
+        timeout-minutes: 15

--- a/github-actions/network/impostor-commit.yaml
+++ b/github-actions/network/impostor-commit.yaml
@@ -1,0 +1,46 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: impostor-commit
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Verifies that the SHA pinned in a uses: field matches the commit the
+      version tag currently resolves to on GitHub. A mismatch means the tag
+      has been moved to point to different (potentially malicious) code after
+      the workflow was written. Requires the version tag to be present as an
+      inline comment (e.g. "uses: actions/foo@sha  # v1.2.3") and network
+      access to api.github.com at scan time. Unauthenticated requests are
+      subject to GitHub's rate limit (60/hour); set GITHUB_TOKEN for higher
+      limits.
+spec:
+  evaluation:
+    mode: JSON
+  variables:
+    - name: ghAPI
+      expression: '"https://api.github.com/repos"'
+  validations:
+    - message: >
+        Pinned SHA does not match the commit the version tag currently points
+        to on GitHub — the tag may have been moved to malicious code. Re-pin
+        to the current commit SHA for the intended tag and verify the diff.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            ('uses-tag' in s) &&
+            s['uses-tag'] != "" &&
+            s.uses.matches('@[a-f0-9]{40}$') &&
+            (
+              http.Get(
+                variables.ghAPI + "/" +
+                string(s.uses).split('@')[0] +
+                "/git/ref/tags/" +
+                string(s['uses-tag'])
+              )['object']['sha'] != string(s.uses).split('@')[1]
+            )
+          )
+        )

--- a/github-actions/network/known-vulnerable-actions.yaml
+++ b/github-actions/network/known-vulnerable-actions.yaml
@@ -39,7 +39,7 @@ spec:
                   '","ecosystem":"GitHub Actions"},"version":"' +
                   string(s['uses-tag']) + '"}'
                 )
-              )
+              ).vulns
             ) > 0
           )
         )

--- a/github-actions/network/known-vulnerable-actions.yaml
+++ b/github-actions/network/known-vulnerable-actions.yaml
@@ -1,0 +1,45 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: known-vulnerable-actions
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Cross-references each pinned action against the OSV.dev vulnerability
+      database using the version tag extracted from the inline comment
+      (e.g. "uses: actions/foo@sha  # v1.2.3"). If OSV.dev reports a known
+      vulnerability for that action at that version the step fails. Requires
+      network access to api.osv.dev at scan time. Annotate each uses: line
+      with a version comment so the tag is available for the lookup.
+spec:
+  evaluation:
+    mode: JSON
+  variables:
+    - name: osvURL
+      expression: '"https://api.osv.dev/v1/query"'
+  validations:
+    - message: >
+        Step uses an action with a known security vulnerability. Update to a
+        patched version, re-pin to the new SHA, and update the version comment.
+        Check https://osv.dev for details on the specific advisory.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            ('uses-tag' in s) &&
+            s['uses-tag'] != "" &&
+            size(
+              http.Post(
+                variables.osvURL,
+                json.unmarshal(
+                  '{"package":{"name":"' + string(s.uses).split('@')[0] +
+                  '","ecosystem":"GitHub Actions"},"version":"' +
+                  string(s['uses-tag']) + '"}'
+                )
+              )
+            ) > 0
+          )
+        )

--- a/github-actions/network/require-slsa-attestation.yaml
+++ b/github-actions/network/require-slsa-attestation.yaml
@@ -1,0 +1,69 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: require-slsa-attestation
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      For each third-party action pinned to a full commit SHA, queries the
+      GitHub Attestations API to verify that at least one SLSA provenance
+      attestation exists for that commit. Actions without attestations
+      cannot have their build provenance verified — meaning there is no
+      cryptographic proof that the published action was built from the
+      claimed source code.
+
+      Background: GitHub Artifact Attestations (released 2024) allow action
+      authors to generate SLSA Build Level 2 provenance using
+      slsa-framework/slsa-github-generator or actions/attest-build-provenance.
+      At the time of the March 2026 Trivy/Checkmarx supply-chain attacks,
+      neither aquasecurity/trivy-action nor checkmarx/ast-github-action
+      published SLSA attestations — meaning consumers had no independent
+      way to verify whether the code they ran matched the published source.
+
+      Note: This policy requires network access to api.github.com at scan
+      time. Unauthenticated requests are subject to GitHub's rate limit
+      (60/hour); set GITHUB_TOKEN for higher limits. Only actions pinned to
+      a full 40-character commit SHA are checked; tag references are skipped
+      (use require-pinned-actions to enforce SHA pinning first).
+
+      Limitation: The GitHub attestation API queries artifact attestations
+      by subject digest (sha256 of a built artifact). This policy checks
+      whether the action's repository has published any SLSA attestations
+      at all. A more precise check would verify attestation for the exact
+      artifact at the pinned SHA; this requires the action author to publish
+      attestations as part of their release workflow.
+spec:
+  evaluation:
+    mode: JSON
+  variables:
+    - name: ghAPI
+      expression: '"https://api.github.com/repos"'
+  validations:
+    - message: >
+        This action is pinned to a commit SHA but its repository has not
+        published any SLSA provenance attestations. Without attestations,
+        there is no cryptographic proof that the code you are running was
+        built from the claimed source. Ask the action author to add
+        'actions/attest-build-provenance' to their release workflow, or
+        use an action that already publishes SLSA attestations.
+
+        To check manually: gh attestation verify oci://ghcr.io/<owner>/<repo>
+        or visit https://github.com/<owner>/<repo>/attestations
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            s.uses.matches('@[a-f0-9]{40}$') &&
+            !s.uses.startsWith('./') &&
+            size(
+              http.Get(
+                variables.ghAPI + "/" +
+                string(s.uses).split('@')[0] +
+                "/attestations"
+              )['attestations']
+            ) == 0
+          )
+        )

--- a/github-actions/no-always-true-condition.yaml
+++ b/github-actions/no-always-true-condition.yaml
@@ -1,0 +1,30 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-always-true-step-condition
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: logic
+    policies.kyverno.io/description: >
+      An if condition set to the literal boolean true (or the string "true")
+      always evaluates to true, making the condition meaningless. This is
+      almost always a mistake — a leftover from debugging or a YAML parsing
+      issue where an expression was intended. Remove the condition or replace
+      it with the correct expression.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step has if: true, which always evaluates to true and makes the
+        condition meaningless. A security-gate step with if: true provides
+        no protection. Remove the condition or replace it with the intended
+        expression.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            ('if' in s) && (s['if'] == true || s['if'] == 'true')
+          )
+        )

--- a/github-actions/no-curl-pipe-bash.yaml
+++ b/github-actions/no-curl-pipe-bash.yaml
@@ -1,0 +1,38 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-curl-wget-pipe-shell
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Piping curl or wget output directly to bash or sh fetches and immediately
+      executes arbitrary remote code with no integrity check. A compromised
+      server, MITM attack, or redirect can serve a malicious payload. Download
+      the script, verify its checksum or signature, then execute it explicitly.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step pipes curl or wget output directly to bash or sh. This executes
+        arbitrary remote code with no integrity verification. Download the
+        script first, verify its checksum or signature, then execute it
+        explicitly.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) &&
+            (s.run.contains('curl') || s.run.contains('wget')) &&
+            (
+              s.run.contains('| bash') ||
+              s.run.contains('| sh') ||
+              s.run.contains('|bash') ||
+              s.run.contains('|sh') ||
+              s.run.contains('| /bin/bash') ||
+              s.run.contains('| /bin/sh')
+            )
+          )
+        )

--- a/github-actions/no-debug-actions.yaml
+++ b/github-actions/no-debug-actions.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-ssh-debug-action
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: rce
+    policies.kyverno.io/description: >
+      Debug actions such as mxschmitt/action-tmate and lhotari/action-upterm
+      open an interactive SSH session on the runner, giving anyone with access
+      to the session URL full shell access to the machine and all secrets
+      loaded into the environment. These actions must never appear in
+      production workflows.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step uses a known SSH debug action that opens an interactive shell on
+        the runner, exposing all secrets and write access to the repository.
+        Remove this step before merging.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) && (
+              s.uses.startsWith('mxschmitt/action-tmate') ||
+              s.uses.startsWith('lhotari/action-upterm')
+            )
+          )
+        )

--- a/github-actions/no-debug-enabled.yaml
+++ b/github-actions/no-debug-enabled.yaml
@@ -1,0 +1,28 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-debug-env-workflow
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      ACTIONS_STEP_DEBUG and ACTIONS_RUNNER_DEBUG cause GitHub Actions to print
+      all environment variables and runner diagnostics to the workflow log,
+      including any secrets injected via the env block. These settings must not
+      be hardcoded in workflow files. Enable them temporarily via repository
+      secrets when debugging and remove them before merging.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow env block enables ACTIONS_STEP_DEBUG or ACTIONS_RUNNER_DEBUG.
+        These settings dump all environment variables (including secrets) to
+        the workflow log. Remove them before merging; enable via repository
+        secrets when debugging.
+      expression: >-
+        !has(object.env) || object.env == null ||
+        (
+          !('ACTIONS_STEP_DEBUG' in object.env) &&
+          !('ACTIONS_RUNNER_DEBUG' in object.env)
+        )

--- a/github-actions/no-excessive-job-permissions.yaml
+++ b/github-actions/no-excessive-job-permissions.yaml
@@ -1,0 +1,36 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-excessive-job-permissions
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: permissions
+    policies.kyverno.io/description: >
+      A job that requests id-token: write (OIDC) together with other write
+      scopes (e.g. contents: write, packages: write) is over-provisioned.
+      id-token: write should be scoped to the specific job that exchanges the
+      OIDC token with a cloud provider. Granting additional write permissions
+      in the same job unnecessarily broadens the blast radius if the job is
+      compromised. Separate cloud-auth jobs from jobs that need write access
+      to repository contents or packages.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job grants id-token: write together with at least one other write
+        scope. id-token: write is for OIDC cloud authentication and should
+        not be combined with broad write permissions in the same job. Split
+        the cloud-auth step into a dedicated job with only id-token: write,
+        or remove write permissions that are not required by this job.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].permissions) &&
+          object.jobs[j].permissions != null &&
+          'id-token' in object.jobs[j].permissions &&
+          object.jobs[j].permissions['id-token'] == 'write' &&
+          object.jobs[j].permissions.exists(k,
+            k != 'id-token' && object.jobs[j].permissions[k] == 'write'
+          )
+        )

--- a/github-actions/no-github-env-injection.yaml
+++ b/github-actions/no-github-env-injection.yaml
@@ -1,0 +1,45 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-github-env-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Writing attacker-controlled GitHub context expressions to $GITHUB_ENV
+      persists untrusted values into the environment for all subsequent steps.
+      Any step that references that env var in an unquoted shell context can
+      be exploited. This check covers PR titles/bodies, issue titles, branch
+      names, comments, reviews, discussions, and workflow_dispatch inputs.
+      The companion policy no-secret-written-to-github-env covers the secrets
+      case. Use step-level env blocks with static values instead.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step writes an attacker-controlled context expression to $GITHUB_ENV.
+        The value is then available as an environment variable to every
+        subsequent step, enabling injection if any step uses it in an unquoted
+        shell context. Pass values through step-level env vars with static
+        content, or sanitise before writing.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) &&
+            s.run.contains('$GITHUB_ENV') &&
+            (
+              s.run.contains('${{ github.event.pull_request') ||
+              s.run.contains('${{ github.head_ref') ||
+              s.run.contains('${{ github.event.issue') ||
+              s.run.contains('${{ github.event.comment') ||
+              s.run.contains('${{ github.event.review') ||
+              s.run.contains('${{ github.event.discussion') ||
+              s.run.contains('${{ github.event.inputs.') ||
+              s.run.contains('${{ inputs.') ||
+              s.run.contains('${{ github.event.workflow_run.head_branch')
+            )
+          )
+        )

--- a/github-actions/no-github-path-injection.yaml
+++ b/github-actions/no-github-path-injection.yaml
@@ -1,0 +1,38 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-github-path-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Writing attacker-controlled GitHub context expressions to $GITHUB_PATH
+      appends arbitrary directories to PATH for all subsequent steps. An
+      attacker can use this to shadow trusted binaries with malicious ones.
+      Never write untrusted values to $GITHUB_PATH.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step writes an untrusted context expression to $GITHUB_PATH. An
+        attacker can prepend arbitrary directories to PATH, shadowing trusted
+        binaries with malicious ones in subsequent steps. Never write
+        attacker-controlled values to $GITHUB_PATH.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) &&
+            s.run.contains('$GITHUB_PATH') &&
+            (
+              s.run.contains('${{ github.event.pull_request') ||
+              s.run.contains('${{ github.event.issue') ||
+              s.run.contains('${{ github.head_ref') ||
+              s.run.contains('${{ github.event.comment') ||
+              s.run.contains('${{ github.event.inputs.') ||
+              s.run.contains('${{ inputs.')
+            )
+          )
+        )

--- a/github-actions/no-github-script-injection.yaml
+++ b/github-actions/no-github-script-injection.yaml
@@ -1,0 +1,42 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-github-script-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Using attacker-controlled GitHub context expressions directly in the
+      script: parameter of actions/github-script allows injection of arbitrary
+      JavaScript. Pass untrusted values through step-level env vars and
+      reference them via process.env inside the script instead.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step uses actions/github-script with an untrusted context expression
+        interpolated directly in the script. An attacker can inject arbitrary
+        JavaScript. Pass untrusted values via step-level env vars and read them
+        with process.env inside the script.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            s.uses.startsWith('actions/github-script') &&
+            ('with' in s) &&
+            has(s['with'].script) &&
+            (
+              s['with'].script.contains('${{ github.event.pull_request') ||
+              s['with'].script.contains('${{ github.event.issue') ||
+              s['with'].script.contains('${{ github.head_ref') ||
+              s['with'].script.contains('${{ github.event.comment') ||
+              s['with'].script.contains('${{ github.event.review') ||
+              s['with'].script.contains('${{ github.event.discussion') ||
+              s['with'].script.contains('${{ github.event.inputs.') ||
+              s['with'].script.contains('${{ inputs.')
+            )
+          )
+        )

--- a/github-actions/no-hardcoded-container-credentials.yaml
+++ b/github-actions/no-hardcoded-container-credentials.yaml
@@ -1,0 +1,39 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-hardcoded-credentials-step-env
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      Hardcoded container registry credentials (DOCKER_PASSWORD, REGISTRY_TOKEN,
+      etc.) in workflow env blocks are stored in plain text in the repository
+      and visible to anyone with read access. Use GitHub Secrets and reference
+      them via ${{ secrets.MY_CREDENTIAL }} so the value is never stored in
+      source control.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step-level env block contains a container registry credential with a
+        hardcoded value. Store credentials in GitHub Secrets and reference them
+        with ${{ secrets.MY_CREDENTIAL }} instead.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.env) && s.env != null && (
+              (has(s.env.DOCKER_PASSWORD)    && !string(s.env.DOCKER_PASSWORD).startsWith('${{'))    ||
+              (has(s.env.DOCKER_PASS)        && !string(s.env.DOCKER_PASS).startsWith('${{'))        ||
+              (has(s.env.DOCKER_TOKEN)       && !string(s.env.DOCKER_TOKEN).startsWith('${{'))       ||
+              (has(s.env.DOCKERHUB_PASSWORD) && !string(s.env.DOCKERHUB_PASSWORD).startsWith('${{')) ||
+              (has(s.env.DOCKERHUB_TOKEN)    && !string(s.env.DOCKERHUB_TOKEN).startsWith('${{'))    ||
+              (has(s.env.REGISTRY_PASSWORD)  && !string(s.env.REGISTRY_PASSWORD).startsWith('${{'))  ||
+              (has(s.env.REGISTRY_PASS)      && !string(s.env.REGISTRY_PASS).startsWith('${{'))      ||
+              (has(s.env.REGISTRY_TOKEN)     && !string(s.env.REGISTRY_TOKEN).startsWith('${{'))     ||
+              (has(s.env.GHCR_TOKEN)         && !string(s.env.GHCR_TOKEN).startsWith('${{'))
+            )
+          )
+        )

--- a/github-actions/no-job-level-issues.yaml
+++ b/github-actions/no-job-level-issues.yaml
@@ -1,0 +1,101 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-job-env-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Setting attacker-controlled GitHub context expressions in job-level env
+      blocks propagates untrusted data to every step in the job. If any step
+      uses the variable in an unquoted shell context, command injection is
+      possible. Scope env vars containing attacker-controlled values to the
+      specific step that needs them.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job-level env block contains an attacker-controllable GitHub context
+        expression. An attacker can inject shell commands via these values.
+        Scope the env var to the specific step that needs it and reference it
+        quoted in shell.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].env) &&
+          object.jobs[j].env != null &&
+          !object.jobs[j].env.all(k,
+            !(
+              string(object.jobs[j].env[k]).contains('${{ github.event.pull_request') ||
+              string(object.jobs[j].env[k]).contains('${{ github.head_ref') ||
+              string(object.jobs[j].env[k]).contains('${{ github.event.issue') ||
+              string(object.jobs[j].env[k]).contains('${{ github.event.comment') ||
+              string(object.jobs[j].env[k]).contains('${{ github.event.review') ||
+              string(object.jobs[j].env[k]).contains('${{ github.event.discussion') ||
+              string(object.jobs[j].env[k]).contains('${{ github.event.workflow_run.head_branch')
+            )
+          )
+        )
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-job-unsecure-commands
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      ACTIONS_ALLOW_UNSECURE_COMMANDS in a job-level env block re-enables the
+      deprecated ::set-env and ::add-path workflow commands for all steps in
+      that job. An attacker who influences any log output can inject into
+      environment variables and PATH. Remove this setting.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job env block sets ACTIONS_ALLOW_UNSECURE_COMMANDS. This re-enables
+        deprecated ::set-env and ::add-path commands for all steps in this
+        job, allowing log output to inject into environment variables and
+        PATH. Remove this setting.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].env) &&
+          object.jobs[j].env != null &&
+          'ACTIONS_ALLOW_UNSECURE_COMMANDS' in object.jobs[j].env
+        )
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-job-debug-env
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      ACTIONS_STEP_DEBUG or ACTIONS_RUNNER_DEBUG in a job-level env block
+      causes GitHub Actions to print all environment variables and runner
+      diagnostics to the workflow log, including secrets. These settings must
+      not be hardcoded. Enable them temporarily via repository secrets when
+      debugging.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job env block enables ACTIONS_STEP_DEBUG or ACTIONS_RUNNER_DEBUG.
+        These settings dump all environment variables (including secrets) to
+        the workflow log. Remove them before merging; enable via repository
+        secrets when debugging.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].env) &&
+          object.jobs[j].env != null &&
+          (
+            'ACTIONS_STEP_DEBUG' in object.jobs[j].env ||
+            'ACTIONS_RUNNER_DEBUG' in object.jobs[j].env
+          )
+        )

--- a/github-actions/no-pr-head-ref-in-run.yaml
+++ b/github-actions/no-pr-head-ref-in-run.yaml
@@ -1,0 +1,40 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-pr-head-ref-in-action-input
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Passing github.head_ref (an attacker-controlled branch name) directly
+      in the with: parameters of an action step can lead to injection in
+      actions that interpolate inputs into shell or API calls internally.
+      Branch names can contain special characters including slashes, quotes,
+      and semicolons. Pass head_ref through a step-level env var and validate
+      or sanitise before use. Checkout actions are excluded because they
+      handle ref parameters safely via git plumbing.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step passes github.head_ref directly in a with: parameter to an
+        action. Branch names are attacker-controlled and can contain shell
+        metacharacters or path components that may be interpreted unsafely
+        by the action. Use a step-level env var to hold the value and
+        validate it before passing it to the action, or avoid forwarding
+        raw branch names to external actions.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            !s.uses.contains('checkout') &&
+            ('with' in s) &&
+            s['with'] != null &&
+            s['with'].exists(k,
+              string(s['with'][k]).contains('${{ github.head_ref')
+            )
+          )
+        )

--- a/github-actions/no-reusable-workflow-secrets-inherit.yaml
+++ b/github-actions/no-reusable-workflow-secrets-inherit.yaml
@@ -1,0 +1,29 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-secrets-inherit
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      Using secrets: inherit when calling a reusable workflow forwards every
+      secret from the caller to the callee. If the callee is a third-party
+      workflow or is later compromised, all secrets are exposed. Pass only the
+      specific secrets the callee requires by name.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job calls a reusable workflow with secrets: inherit, forwarding all
+        caller secrets to the callee. If the callee is compromised or
+        third-party, every secret is exposed. Pass only the secrets the callee
+        requires explicitly.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].uses) &&
+          object.jobs[j].uses != '' &&
+          has(object.jobs[j].secrets) &&
+          object.jobs[j].secrets == 'inherit'
+        )

--- a/github-actions/no-script-injection.yaml
+++ b/github-actions/no-script-injection.yaml
@@ -1,0 +1,38 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-untrusted-input-in-run
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Using GitHub context expressions (${{ github.event.* }}) directly inside
+      run steps allows injection of arbitrary shell commands via PR titles,
+      branch names, or commit messages controlled by an attacker. Use an
+      intermediate env var to safely pass attacker-controlled values.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step uses untrusted GitHub context expression in a run step.
+        Attacker-controlled values (PR titles, branch names, review bodies,
+        comments, and discussion content) can inject shell commands. Use an
+        intermediate env var to hold the value, then reference the env var
+        quoted in the run step instead of interpolating the expression directly.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) && (
+              s.run.contains('${{ github.event.pull_request') ||
+              s.run.contains('${{ github.event.issue') ||
+              s.run.contains('${{ github.head_ref') ||
+              s.run.contains('${{ github.event.comment') ||
+              s.run.contains('${{ github.event.review') ||
+              s.run.contains('${{ github.event.discussion') ||
+              s.run.contains('${{ github.event.workflow_run.head_branch')
+            )
+          )
+        )

--- a/github-actions/no-secrets-in-github-env.yaml
+++ b/github-actions/no-secrets-in-github-env.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-secret-written-to-github-env
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      Writing secrets to $GITHUB_ENV persists their values into the environment
+      for all subsequent steps in the job. If any downstream step logs the
+      environment or passes it to an external process, the secret is leaked.
+      Pass secrets directly to the steps that need them via the step-level
+      env block instead.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step writes a secret into $GITHUB_ENV, making it visible to all
+        subsequent steps and any process that inspects the environment. Pass
+        the secret directly to the step that needs it via its own env block
+        instead of persisting it to the job environment.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) &&
+            s.run.contains('${{ secrets.') &&
+            s.run.contains('$GITHUB_ENV')
+          )
+        )

--- a/github-actions/no-self-hosted-runners.yaml
+++ b/github-actions/no-self-hosted-runners.yaml
@@ -1,0 +1,27 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-self-hosted-runners
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: runner-security
+    policies.kyverno.io/description: >
+      Self-hosted runners on public repositories allow any contributor to
+      trigger workflow runs that execute code on your infrastructure. Combined
+      with pull_request_target this is especially dangerous. Use GitHub-hosted
+      runners or restrict triggers to trusted actors only.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job uses a self-hosted runner. On public repositories, any user can
+        trigger workflows that run on your infrastructure. Use GitHub-hosted
+        runners or restrict the trigger to trusted actors only.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          'runs-on' in object.jobs[j] &&
+          object.jobs[j]['runs-on'] != null &&
+          string(object.jobs[j]['runs-on']).contains('self-hosted')
+        )

--- a/github-actions/no-tojson-secrets.yaml
+++ b/github-actions/no-tojson-secrets.yaml
@@ -1,0 +1,31 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-tojson-secrets-in-run
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      toJson(secrets) serialises every secret available to the workflow into a
+      single JSON blob. Any step that logs, exports, or transmits this value
+      leaks all secrets at once. Reference only the specific secrets each step
+      requires by name.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step serialises all secrets with toJson(secrets). This exposes every
+        secret available to the workflow in a single value. Reference only the
+        specific secrets each step requires by name instead.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) && (
+              s.run.contains('toJson(secrets)') ||
+              s.run.contains('toJSON(secrets)')
+            )
+          )
+        )

--- a/github-actions/no-unguarded-comment-trigger.yaml
+++ b/github-actions/no-unguarded-comment-trigger.yaml
@@ -1,0 +1,50 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: comment-trigger-requires-author-check
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: authorization
+    policies.kyverno.io/description: >
+      Workflows triggered by issue_comment run in the base repository context
+      with access to secrets and write permissions. Without an author_association
+      guard, any external contributor can trigger privileged code execution by
+      posting a comment. Restrict execution to trusted actors or switch to the
+      pull_request trigger for contributor workflows.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow uses the issue_comment trigger, which grants any user the
+        ability to trigger privileged code execution by posting a comment.
+        Add an if condition on each job to restrict execution to trusted actors,
+        or switch to the pull_request trigger for contributor workflows.
+      expression: >-
+        !('issue_comment' in object.on)
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: workflow-run-trigger-requires-fork-check
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: authorization
+    policies.kyverno.io/description: >
+      Workflows triggered by workflow_run run with base repository secrets and
+      permissions but can be initiated by a fork PR workflow. Before downloading
+      or using any artifacts from the triggering run, verify that the workflow
+      was not triggered by a fork to avoid executing untrusted code in a
+      privileged context.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow uses the workflow_run trigger, which runs with base repository
+        secrets and permissions but can be initiated by a fork PR workflow.
+        Before using artifacts from the triggering run, check
+        github.event.workflow_run.head_repository.fork to avoid executing
+        untrusted fork code in a privileged context.
+      expression: >-
+        !('workflow_run' in object.on)

--- a/github-actions/no-unguarded-comment-trigger.yaml
+++ b/github-actions/no-unguarded-comment-trigger.yaml
@@ -21,7 +21,10 @@ spec:
         Add an if condition on each job to restrict execution to trusted actors,
         or switch to the pull_request trigger for contributor workflows.
       expression: >-
-        !('issue_comment' in object.on)
+        !has(object['on']) || !(
+          object['on'] == 'issue_comment' ||
+          ('issue_comment' in object['on'])
+        )
 ---
 apiVersion: policies.kyverno.io/v1beta1
 kind: ValidatingPolicy
@@ -47,4 +50,7 @@ spec:
         github.event.workflow_run.head_repository.fork to avoid executing
         untrusted fork code in a privileged context.
       expression: >-
-        !('workflow_run' in object.on)
+        !has(object['on']) || !(
+          object['on'] == 'workflow_run' ||
+          ('workflow_run' in object['on'])
+        )

--- a/github-actions/no-unjustified-write-permissions.yaml
+++ b/github-actions/no-unjustified-write-permissions.yaml
@@ -1,0 +1,66 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-unjustified-write-permissions
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: least-privilege
+    policies.kyverno.io/description: >
+      A job-level write permission that no step in the job requires violates
+      least-privilege. For each known action in the manifest the policy checks
+      whether the write permissions granted to the job are actually needed.
+      Jobs that contain at least one action not in the manifest are skipped
+      (the unknown action may legitimately require the permission). Extend
+      the actionRequires variable in a custom policy overlay to cover your
+      own internal actions.
+spec:
+  evaluation:
+    mode: JSON
+  variables:
+    - name: actionRequires
+      expression: >-
+        {
+          "actions/checkout":                  ["contents"],
+          "actions/upload-artifact":           [],
+          "actions/download-artifact":         [],
+          "actions/create-release":            ["contents"],
+          "actions/deploy-pages":              ["pages"],
+          "docker/build-push-action":          ["packages"],
+          "docker/login-action":               [],
+          "github/codeql-action/init":         ["actions"],
+          "github/codeql-action/autobuild":    ["actions"],
+          "github/codeql-action/analyze":      ["security-events"],
+          "github/codeql-action/upload-sarif": ["security-events"],
+          "softprops/action-gh-release":       ["contents"],
+          "peter-evans/create-pull-request":   ["contents", "pull-requests"],
+          "peaceiris/actions-gh-pages":        ["contents"],
+          "aws-actions/configure-aws-credentials": ["id-token"],
+          "azure/login":                       ["id-token"],
+          "google-github-actions/auth":        ["id-token"]
+        }
+  validations:
+    - message: >
+        Job grants a write permission that no step in the job requires.
+        Remove write permissions not needed by any action in this job. If you
+        use an internal or unlisted action that requires this permission, add
+        it to the actionRequires map in a custom policy overlay.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].permissions) &&
+          object.jobs[j].permissions != null &&
+          object.jobs[j].permissions != "write-all" &&
+          object.jobs[j].permissions != "read-all" &&
+          object.jobs[j].permissions.exists(perm,
+            object.jobs[j].permissions[perm] == "write" &&
+            !object.jobs[j].steps.exists(s,
+              has(s.uses) &&
+              !(s.uses.split('@')[0] in variables.actionRequires)
+            ) &&
+            !object.jobs[j].steps.exists(s,
+              has(s.uses) &&
+              s.uses.split('@')[0] in variables.actionRequires &&
+              perm in variables.actionRequires[s.uses.split('@')[0]]
+            )
+          )
+        )

--- a/github-actions/no-unjustified-write-permissions.yaml
+++ b/github-actions/no-unjustified-write-permissions.yaml
@@ -20,7 +20,7 @@ spec:
     - name: actionRequires
       expression: >-
         {
-          "actions/checkout":                  ["contents"],
+          "actions/checkout":                  [],
           "actions/upload-artifact":           [],
           "actions/download-artifact":         [],
           "actions/create-release":            ["contents"],
@@ -51,6 +51,8 @@ spec:
           object.jobs[j].permissions != null &&
           object.jobs[j].permissions != "write-all" &&
           object.jobs[j].permissions != "read-all" &&
+          has(object.jobs[j].steps) &&
+          object.jobs[j].steps != null &&
           object.jobs[j].permissions.exists(perm,
             object.jobs[j].permissions[perm] == "write" &&
             !object.jobs[j].steps.exists(s,

--- a/github-actions/no-unsecure-commands.yaml
+++ b/github-actions/no-unsecure-commands.yaml
@@ -1,0 +1,25 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-unsecure-commands-workflow-env
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      ACTIONS_ALLOW_UNSECURE_COMMANDS re-enables the deprecated ::set-env and
+      ::add-path workflow commands, which allow any log output to inject values
+      into environment variables and the PATH for subsequent steps. An attacker
+      who influences any output can use this to execute arbitrary code. This
+      setting must never be used.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow env block sets ACTIONS_ALLOW_UNSECURE_COMMANDS. This
+        re-enables deprecated ::set-env and ::add-path commands, allowing
+        any log output to inject into environment variables and PATH for all
+        jobs. Remove this setting.
+      expression: >-
+        !has(object.env) || object.env == null ||
+        !('ACTIONS_ALLOW_UNSECURE_COMMANDS' in object.env)

--- a/github-actions/no-untrusted-env-vars.yaml
+++ b/github-actions/no-untrusted-env-vars.yaml
@@ -1,0 +1,35 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-workflow-env-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Setting attacker-controlled GitHub context expressions in workflow-level
+      env blocks propagates untrusted data to every downstream step. If any
+      step uses the variable in an unquoted shell context, command injection
+      is possible. Scope env vars containing attacker-controlled values to the
+      specific step that needs them.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow-level env block contains an attacker-controllable GitHub
+        context expression. An attacker can inject shell commands via these
+        values. Scope the env var to the specific step that needs it and
+        reference it quoted in shell, or use an intermediate sanitisation step.
+      expression: >-
+        !has(object.env) || object.env == null ||
+        object.env.all(k,
+          !(
+            string(object.env[k]).contains('${{ github.event.pull_request') ||
+            string(object.env[k]).contains('${{ github.head_ref') ||
+            string(object.env[k]).contains('${{ github.event.issue') ||
+            string(object.env[k]).contains('${{ github.event.comment') ||
+            string(object.env[k]).contains('${{ github.event.review') ||
+            string(object.env[k]).contains('${{ github.event.discussion') ||
+            string(object.env[k]).contains('${{ github.event.workflow_run.head_branch')
+          )
+        )

--- a/github-actions/no-workflow-dispatch-injection.yaml
+++ b/github-actions/no-workflow-dispatch-injection.yaml
@@ -1,0 +1,32 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-workflow-dispatch-injection
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: injection
+    policies.kyverno.io/description: >
+      Using workflow_dispatch inputs (${{ github.event.inputs.* }} or
+      ${{ inputs.* }}) directly inside run steps allows injection of arbitrary
+      shell commands. Workflow inputs are caller-controlled and must be passed
+      through intermediate env vars, never interpolated directly in shell.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step interpolates a workflow_dispatch input directly in a run step.
+        Inputs are caller-controlled and can contain shell metacharacters.
+        Pass the value via a step-level env var and reference it quoted in
+        shell instead of interpolating the expression directly.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) && (
+              s.run.contains('${{ github.event.inputs.') ||
+              s.run.contains('${{ inputs.')
+            )
+          )
+        )

--- a/github-actions/no-workflow-level-secrets.yaml
+++ b/github-actions/no-workflow-level-secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-secrets-in-workflow-env
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: secret-exposure
+    policies.kyverno.io/description: >
+      Secrets defined in the workflow-level env block are accessible to all
+      jobs, including those triggered by fork pull requests, potentially
+      exposing them to untrusted code. Move secret references to the specific
+      job or step that requires them.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow-level env var references a secret. Workflow-level env vars
+        are accessible to all jobs including fork PR runs. Move secret
+        references to the specific job or step that requires them.
+      expression: >-
+        !has(object.env) || object.env == null ||
+        object.env.all(k,
+          !string(object.env[k]).startsWith('${{ secrets.')
+        )

--- a/github-actions/no-write-all-permissions.yaml
+++ b/github-actions/no-write-all-permissions.yaml
@@ -1,0 +1,27 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-write-all-permissions
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: least-privilege
+    policies.kyverno.io/description: >
+      permissions: write-all grants the GITHUB_TOKEN write access to every
+      repository scope, equivalent to admin access during the workflow run.
+      Grant only the specific permissions required for the workflow or job.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow or job sets permissions to write-all. Grant only the specific
+        permissions required (e.g., contents: read, pull-requests: write).
+      expression: >-
+        (!has(object.permissions) || object.permissions != 'write-all') &&
+        (
+          object.jobs == null ||
+          !object.jobs.exists(j,
+            has(object.jobs[j].permissions) &&
+            object.jobs[j].permissions == 'write-all'
+          )
+        )

--- a/github-actions/pull-request-target-with-checkout.yaml
+++ b/github-actions/pull-request-target-with-checkout.yaml
@@ -1,0 +1,33 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: no-prt-with-pr-ref-checkout
+  annotations:
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Workflows triggered by pull_request_target run with write permissions and
+      access to secrets. Checking out the PR branch (e.g. with.ref: ${{ github.event.pull_request.head.sha }})
+      exposes those privileges to attacker-controlled code. Use pull_request instead,
+      or restrict checkout to the base branch.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow uses pull_request_target and checks out the PR branch with a
+        pull_request context ref. This gives attacker-controlled code access to
+        secrets and write permissions. Use pull_request trigger or only check
+        out the base branch.
+      expression: >-
+        !('pull_request_target' in object.on) ||
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) && s.uses.contains('checkout') &&
+            ('with' in s) && has(s['with'].ref) &&
+            (s['with'].ref.contains('${{ github.event.pull_request') ||
+             s['with'].ref.contains('${{ github.head_ref'))
+          )
+        )

--- a/github-actions/require-concurrency-on-release.yaml
+++ b/github-actions/require-concurrency-on-release.yaml
@@ -1,0 +1,25 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: release-workflow-has-concurrency
+  annotations:
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/category: resource-management
+    policies.kyverno.io/description: >
+      Release workflows without a concurrency group can run simultaneously if
+      two releases are published in quick succession. Concurrent publish jobs
+      can corrupt release artifacts, double-publish packages, or leave the
+      registry in an inconsistent state. Add a concurrency block to serialise
+      release runs.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow is triggered by a release event but has no concurrency block.
+        Two simultaneous release runs can corrupt artifacts or publish duplicate
+        packages. Add a concurrency group to serialise execution, for example:
+        concurrency: { group: "release-${{ github.ref }}", cancel-in-progress: true }
+      expression: >-
+        !('release' in object.on) ||
+        (has(object.concurrency) && object.concurrency != null)

--- a/github-actions/require-permissions-block.yaml
+++ b/github-actions/require-permissions-block.yaml
@@ -1,0 +1,23 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: workflow-has-permissions
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: least-privilege
+    policies.kyverno.io/description: >
+      Workflows without an explicit permissions block inherit the repository's
+      default token permissions, which is write for all scopes on many
+      repositories. Always declare permissions explicitly at the workflow level
+      and grant write only where needed at the job level.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Workflow has no top-level permissions block. Without explicit permissions,
+        GITHUB_TOKEN inherits repository defaults (often write). Add
+        'permissions: read-all' at the workflow level and grant write only where
+        needed.
+      expression: >-
+        has(object.permissions) && object.permissions != null

--- a/github-actions/require-pinned-actions.yaml
+++ b/github-actions/require-pinned-actions.yaml
@@ -1,0 +1,58 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: actions-pinned-to-sha
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Unpinned actions (using tags like @v3 or @main) are vulnerable to tag
+      mutation. An attacker who compromises an action's repository can push a
+      malicious version under an existing tag. Pin all actions to a full
+      40-character commit SHA to guarantee immutability.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        One or more steps use an action not pinned to a full commit SHA. Use
+        the format 'owner/repo@<40-char-sha>' to prevent supply chain attacks
+        via tag mutation.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.uses) &&
+            !s.uses.startsWith('./') &&
+            !s.uses.matches('^[^@]+@[0-9a-f]{40}$')
+          )
+        )
+---
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: reusable-workflows-pinned-to-sha
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Reusable workflows called via jobs[*].uses must be pinned to a full
+      commit SHA. Tag or branch references are mutable and can be silently
+      replaced with malicious content.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        One or more jobs call a reusable workflow not pinned to a full
+        40-character commit SHA. Pin every external reusable workflow reference
+        to a full SHA to prevent supply chain attacks via tag mutation.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].uses) &&
+          object.jobs[j].uses != '' &&
+          !object.jobs[j].uses.startsWith('./') &&
+          !object.jobs[j].uses.matches('^[^@]+@[0-9a-f]{40}$')
+        )

--- a/github-actions/require-pinned-containers.yaml
+++ b/github-actions/require-pinned-containers.yaml
@@ -1,0 +1,31 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: container-image-pinned-to-digest
+  annotations:
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/category: supply-chain
+    policies.kyverno.io/description: >
+      Container images referenced with mutable tags (e.g. ubuntu:latest) are
+      vulnerable to image substitution. A registry compromise or stale local
+      cache can silently change what executes in the job. Pin all container
+      images to a specific SHA256 digest to guarantee immutability.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Job uses a container image not pinned to a SHA256 digest. Use the
+        format 'image@sha256:<digest>' to prevent unexpected image substitution
+        from tag mutation or cache poisoning.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          has(object.jobs[j].container) &&
+          object.jobs[j].container != null &&
+          !(
+            ('image' in object.jobs[j].container)
+              ? object.jobs[j].container.image.contains('@sha256:')
+              : string(object.jobs[j].container).contains('@sha256:')
+          )
+        )

--- a/github-actions/require-timeout-minutes.yaml
+++ b/github-actions/require-timeout-minutes.yaml
@@ -1,0 +1,28 @@
+apiVersion: policies.kyverno.io/v1beta1
+kind: ValidatingPolicy
+metadata:
+  name: steps-have-timeout
+  annotations:
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/category: resource-management
+    policies.kyverno.io/description: >
+      Steps without timeout-minutes can run indefinitely, enabling
+      denial-of-service attacks against your runner pool and consuming GitHub
+      Actions minutes. Set a timeout-minutes value appropriate for the
+      expected runtime of each run step.
+spec:
+  evaluation:
+    mode: JSON
+  validations:
+    - message: >
+        Step has no timeout-minutes set. Without a timeout, a hung step can
+        consume all available runner minutes. Add a timeout-minutes value
+        appropriate for the expected runtime.
+      expression: >-
+        object.jobs == null ||
+        !object.jobs.exists(j,
+          object.jobs[j].steps != null &&
+          object.jobs[j].steps.exists(s,
+            has(s.run) && !('timeout-minutes' in s)
+          )
+        )


### PR DESCRIPTION
**Description:**

Kyverno policies to scan GH actions

Works with
» .//nctl scan github-actions -h
Scan GitHub Actions workflow files for security vulnerabilities

Usage:
  nctl scan github-actions [path] [flags]

Examples:

  # Scan the current directory for GitHub Actions workflows
  nctl scan github-actions

  # Scan a specific local repository path
  nctl scan github-actions /path/to/repo

  # Scan with additional custom policies on top of the built-in set
  nctl scan github-actions --policies ./my-policies --severity high

  # Output SARIF for GitHub Code Scanning integration
  nctl scan github-actions --output sarif > results.sarif

  # Publish results to Nirmata Control Hub
  nctl scan github-actions --publish

  # Scan and save a JSON report
  nctl scan github-actions --scan-report ./report.json



