### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -14,18 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab  # v1
         with:
           version: v3.7.2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
         with:
           python-version: 3.12
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@6b64532d456fa490a3da177fbd181ac4c8192b58  # v2.2.0
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
 
@@ -21,9 +21,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968  # v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/reusable-chainsaw.yaml
+++ b/.github/workflows/reusable-chainsaw.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Clone Kyverno Policies Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: nirmata/kyverno-policies
           ref: ${{ inputs.kyverno_policies_branch }}
@@ -36,12 +36,12 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: 'stable'
 
       - name: Install Kyverno CLI
-        uses: kyverno/action-install-cli@v0.2.0
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289  # v0.2.0
         with:
           release: v1.14.2
 
@@ -63,7 +63,7 @@ jobs:
         working-directory: kyverno-policies
 
       - name: Install chainsaw
-        uses: kyverno/action-install-chainsaw@v0.2.7
+        uses: kyverno/action-install-chainsaw@7ad918efe13995d01bafa59aef8203a5246f5d04  # v0.2.7
 
       - name: Verify Chainsaw Installation
         run: chainsaw version


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v3 -> @f43a0e5f...`
- `azure/setup-helm@v1 -> @18bc7681...`
- `actions/setup-python@v2 -> @e9aba2c8...`
- `helm/chart-testing-action@v2.2.0 -> @6b64532d...`
- `actions/checkout@v3 -> @f43a0e5f...`
- `azure/setup-helm@v3 -> @5119fcb9...`
- `helm/chart-releaser-action@v1.5.0 -> @be16258d...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/setup-go@v5 -> @40f1582b...`
- `kyverno/action-install-cli@v0.2.0 -> @fcee92fc...`
- `kyverno/action-install-chainsaw@v0.2.7 -> @7ad918ef...`


### Why

This repo was flagged as **HIGH** risk: unpinned actions triggered by pull requests allow fork-based supply chain attacks.

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
