### PR TITLE
fix(terraform/s3): migrate all s3 policies to use resource_changes

### DIFF
--- a/terraform/plan/s3-best-practices/abort-incomplete-uploads/abort-incomplete-uploads.yaml
+++ b/terraform/plan/s3-best-practices/abort-incomplete-uploads/abort-incomplete-uploads.yaml
@@ -7,7 +7,7 @@ metadata:
     policies.kyverno.io/category: AWS S3 Security Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      Amazon S3 supports a bucket lifecycle rule that you can use to direct Amazon S3 
+      Amazon S3 supports a bucket lifecycle rule that you can use to direct Amazon S3
       to stop multipart uploads that aren't completed within a specified number of days
       after being initiated. When a multipart upload isn't completed within the specified time
       frame, it becomes eligible for an abort operation. Amazon S3 then stops the multipart
@@ -27,33 +27,38 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-lifecycle
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_lifecycle_configuration')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: lifecycle_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_lifecycle_configuration')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
-    - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_lifecycle_configuration')
+    - expression: "variables.lifecycle_resources.size() >= variables.s3_buckets.size()"
       message: "Use the 'aws_s3_bucket_lifecycle_configuration' resource to enable lifecycle configuration."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_lifecycle_configuration').all(config,
-          has(config.values.rule) && 
-          config.values.rule != null && 
-          config.values.rule.exists(rule, has(rule.status) && rule.status == 'Enabled')
-        )
-      message: "S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'"
+        variables.lifecycle_resources.all(lc,
+          lc.change.after.rule.orValue([]).exists(rule,
+            rule.status == 'Enabled'))
+      message: "S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_lifecycle_configuration').all(config,
-          has(config.values.rule) && 
-          config.values.rule != null && 
-          config.values.rule.filter(rule, has(rule.status) && rule.status == 'Enabled').all(enabledRule,
-            has(enabledRule.abort_incomplete_multipart_upload) && 
-            enabledRule.abort_incomplete_multipart_upload != null &&
-            enabledRule.abort_incomplete_multipart_upload.all(abort, 
-              has(abort.days_after_initiation) && 
-              abort.days_after_initiation != null &&
-              int(abort.days_after_initiation) > 0
-            )
-          )
-        )
-      message: "Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block"
-
+        variables.lifecycle_resources.all(lc,
+          lc.change.after.rule.orValue([]).filter(rule,
+            rule.status == 'Enabled').all(rule,
+              rule.?abort_incomplete_multipart_upload.orValue([]).size() > 0
+              && rule.abort_incomplete_multipart_upload[0].days_after_initiation > 0))
+      message: "Set the 'days_after_initiation' argument value to a Positive Integer value in 'abort_incomplete_multipart_upload' inside the lifecycle configuration block."

--- a/terraform/plan/s3-best-practices/disable-s3-acl/disable-s3-acl.yaml
+++ b/terraform/plan/s3-best-practices/disable-s3-acl/disable-s3-acl.yaml
@@ -8,9 +8,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       S3 Object Ownership is an Amazon S3 bucket-level setting that
-      you can use to control ownership of objects uploaded to your bucket 
+      you can use to control ownership of objects uploaded to your bucket
       and to disable or enable ACLs. By default, Object Ownership is set to
-      the Bucket owner enforced setting and all ACLs are disabled. 
+      the Bucket owner enforced setting and all ACLs are disabled.
       When ACLs are disabled, the bucket owner owns all the objects in the bucket
       and manages access to data exclusively using access management policies.
 spec:
@@ -28,17 +28,24 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket-ownership-controls
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_ownership_controls' || r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-ownership-controls
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket_ownership_controls' || rc.type == 'aws_s3_bucket')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: ownership_controls
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_ownership_controls')"
   validations:
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_ownership_controls').all(controls,
-          has(controls.values.rule) && 
-          controls.values.rule != null &&
-          controls.values.rule.exists(rule,
-            has(rule.object_ownership) && 
-            rule.object_ownership == 'BucketOwnerEnforced'
-          )
-        )
-      message: "Access Control List(ACL) should be disabled for an S3 Bucket" 
+        variables.ownership_controls.all(oc,
+          oc.change.after.rule.orValue([]).exists(rule,
+            rule.object_ownership == 'BucketOwnerEnforced'))
+      message: "Access Control List (ACL) should be disabled for an S3 Bucket."

--- a/terraform/plan/s3-best-practices/enable-aws-cloudtrail/enable-aws-cloudtrail.yaml
+++ b/terraform/plan/s3-best-practices/enable-aws-cloudtrail/enable-aws-cloudtrail.yaml
@@ -8,9 +8,9 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       CloudTrail stores Amazon S3 data event logs in an S3 bucket of your choosing.
-      Consider using a bucket in a separate AWS account to better organize events from 
+      Consider using a bucket in a separate AWS account to better organize events from
       multiple buckets that you might own into a central place for easier querying and
-      analysis. AWS Organizations helps you create an AWS account that is linked to 
+      analysis. AWS Organizations helps you create an AWS account that is linked to
       the account that owns the bucket that you're monitoring.
 spec:
   validationActions:
@@ -27,14 +27,23 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-cloudtrail
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && rc.type == 'aws_cloudtrail'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+    - name: cloudtrail_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_cloudtrail')"
   validations:
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_cloudtrail').all(trail,
-          has(trail.values.enable_logging) && 
-          trail.values.enable_logging == true
-        )
-      message: "Set the enable_logging argument in aws_cloudtrail resource to true"
-                   
+        variables.cloudtrail_resources.all(trail,
+          trail.change.after.enable_logging.orValue(false) == true)
+      message: "Set the enable_logging argument in aws_cloudtrail resource to true."

--- a/terraform/plan/s3-best-practices/enable-kms-encryption/enable-kms-encryption.yaml
+++ b/terraform/plan/s3-best-practices/enable-kms-encryption/enable-kms-encryption.yaml
@@ -8,11 +8,11 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
       All Amazon S3 buckets have encryption configured by default,
-      and all new objects that are uploaded to an S3 bucket are automatically 
-      encrypted at rest. Server-side encryption with Amazon S3 managed keys (SSE-S3) 
+      and all new objects that are uploaded to an S3 bucket are automatically
+      encrypted at rest. Server-side encryption with Amazon S3 managed keys (SSE-S3)
       is the default encryption configuration for every bucket in Amazon S3. To use a
       different type of encryption, you can either specify the type of server-side encryption
-      to use in your S3 PUT requests, or you can set the default encryption configuration in 
+      to use in your S3 PUT requests, or you can set the default encryption configuration in
       the destination bucket.
 spec:
   validationActions:
@@ -29,25 +29,32 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-encryption
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_server_side_encryption_configuration')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: encryption_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_server_side_encryption_configuration')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
+    - expression: "variables.encryption_resources.size() >= variables.s3_buckets.size()"
+      message: "Use the 'aws_s3_bucket_server_side_encryption_configuration' resource to set the S3 server side encryption to KMS."
     - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_server_side_encryption_configuration')
-      message: "Use the 'aws_s3_bucket_server_side_encryption_configuration' resource to set the S3 server side encryption to KMS"
-    - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_server_side_encryption_configuration').all(encryption,
-          has(encryption.values.rule) && 
-          encryption.values.rule != null &&
-          encryption.values.rule.exists(rule,
-            has(rule.apply_server_side_encryption_by_default) &&
-            rule.apply_server_side_encryption_by_default != null &&
-            rule.apply_server_side_encryption_by_default.exists(defaultEnc,
-              has(defaultEnc.sse_algorithm) && 
-              defaultEnc.sse_algorithm == 'aws:kms'
-            )
-          )
-        )
-      message: "S3 server side encryption is not set to KMS"
-  
+        variables.encryption_resources.all(enc,
+          enc.change.after.rule.orValue([]).exists(rule,
+            rule.apply_server_side_encryption_by_default.orValue([]).exists(d,
+              d.sse_algorithm == 'aws:kms')))
+      message: "S3 server side encryption is not set to KMS."

--- a/terraform/plan/s3-best-practices/enable-kms-encryption/test/bad-payload-02.json
+++ b/terraform/plan/s3-best-practices/enable-kms-encryption/test/bad-payload-02.json
@@ -388,66 +388,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "acceleration_status": "",
-          "acl": null,
-          "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-          "bucket": "nitish-s3-bucket-encryption",
-          "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-          "bucket_prefix": "",
-          "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-          "cors_rule": [],
-          "force_destroy": false,
-          "grant": [
-            {
-              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-              "permissions": [
-                "FULL_CONTROL"
-              ],
-              "type": "CanonicalUser",
-              "uri": ""
-            }
-          ],
-          "hosted_zone_id": "Z3BJ6K6RIION7M",
-          "id": "nitish-s3-bucket-encryption",
-          "lifecycle_rule": [],
-          "logging": [],
-          "object_lock_configuration": [],
-          "object_lock_enabled": false,
-          "policy": "",
-          "region": "us-west-2",
-          "replication_configuration": [],
-          "request_payer": "BucketOwner",
-          "server_side_encryption_configuration": [
-            {
-              "rule": [
-                {
-                  "apply_server_side_encryption_by_default": [
-                    {
-                      "kms_master_key_id": "",
-                      "sse_algorithm": "AES256"
-                    }
-                  ],
-                  "bucket_key_enabled": false
-                }
-              ]
-            }
-          ],
-          "tags": {},
-          "tags_all": {},
-          "timeouts": null,
-          "versioning": [
-            {
-              "enabled": false,
-              "mfa_delete": false
-            }
-          ],
-          "website": [],
-          "website_domain": null,
-          "website_endpoint": null
-        },
+        "before": null,
         "after": {
           "acceleration_status": "",
           "acl": null,
@@ -724,8 +667,7 @@
         "name": "aws",
         "full_name": "registry.terraform.io/hashicorp/aws",
         "version_constraint": "~> 4.16",
-        "expressions": {
-        }
+        "expressions": {}
       }
     },
     "root_module": {

--- a/terraform/plan/s3-best-practices/enable-kms-encryption/test/bad-payload-03.json
+++ b/terraform/plan/s3-best-practices/enable-kms-encryption/test/bad-payload-03.json
@@ -1,31 +1,501 @@
 {
-    "format_version": "1.2",
+  "format_version": "1.2",
+  "terraform_version": "1.6.6",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_kms_key.mykey",
+          "mode": "managed",
+          "type": "aws_kms_key",
+          "name": "mykey",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bypass_policy_lockout_safety_check": false,
+            "custom_key_store_id": null,
+            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+            "deletion_window_in_days": 10,
+            "description": "This key is used to encrypt bucket objects",
+            "enable_key_rotation": false,
+            "is_enabled": true,
+            "key_usage": "ENCRYPT_DECRYPT",
+            "tags": null
+          },
+          "sensitive_values": {
+            "tags_all": {}
+          }
+        },
+        {
+          "address": "aws_s3_bucket.mybucket",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "mybucket",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
+            "bucket": "nitish-s3-bucket-encryption",
+            "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
+            "bucket_prefix": "",
+            "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [
+              {
+                "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z3BJ6K6RIION7M",
+            "id": "nitish-s3-bucket-encryption",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-west-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {
+                        "kms_master_key_id": "",
+                        "sse_algorithm": "AES256"
+                      }
+                    ],
+                    "bucket_key_enabled": false
+                  }
+                ]
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null,
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [
+              {
+                "permissions": [
+                  false
+                ]
+              }
+            ],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [
+              {
+                "rule": [
+                  {
+                    "apply_server_side_encryption_by_default": [
+                      {}
+                    ]
+                  }
+                ]
+              }
+            ],
+            "tags": {},
+            "tags_all": {},
+            "versioning": [
+              {}
+            ],
+            "website": []
+          }
+        }
+      ]
+    }
+  },
+  "resource_drift": [
+    {
+      "address": "aws_s3_bucket.mybucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "mybucket",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
+          "bucket": "nitish-s3-bucket-encryption",
+          "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "nitish-s3-bucket-encryption",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": null,
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
+          "bucket": "nitish-s3-bucket-encryption",
+          "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "nitish-s3-bucket-encryption",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        },
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        }
+      }
+    }
+  ],
+  "resource_changes": [
+    {
+      "address": "aws_kms_key.mykey",
+      "mode": "managed",
+      "type": "aws_kms_key",
+      "name": "mykey",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bypass_policy_lockout_safety_check": false,
+          "custom_key_store_id": null,
+          "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+          "deletion_window_in_days": 10,
+          "description": "This key is used to encrypt bucket objects",
+          "enable_key_rotation": false,
+          "is_enabled": true,
+          "key_usage": "ENCRYPT_DECRYPT",
+          "tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "id": true,
+          "key_id": true,
+          "multi_region": true,
+          "policy": true,
+          "tags_all": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "tags_all": {}
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket.mybucket",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "mybucket",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
+          "bucket": "nitish-s3-bucket-encryption",
+          "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
+          "bucket_prefix": "",
+          "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": false,
+          "grant": [
+            {
+              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z3BJ6K6RIION7M",
+          "id": "nitish-s3-bucket-encryption",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-2",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {
+                      "kms_master_key_id": "",
+                      "sse_algorithm": "AES256"
+                    }
+                  ],
+                  "bucket_key_enabled": false
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "timeouts": null,
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        },
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [
+            {
+              "permissions": [
+                false
+              ]
+            }
+          ],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [
+            {
+              "rule": [
+                {
+                  "apply_server_side_encryption_by_default": [
+                    {}
+                  ]
+                }
+              ]
+            }
+          ],
+          "tags": {},
+          "tags_all": {},
+          "versioning": [
+            {}
+          ],
+          "website": []
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
     "terraform_version": "1.6.6",
-    "planned_values": {
+    "values": {
       "root_module": {
         "resources": [
-          {
-            "address": "aws_kms_key.mykey",
-            "mode": "managed",
-            "type": "aws_kms_key",
-            "name": "mykey",
-            "provider_name": "registry.terraform.io/hashicorp/aws",
-            "schema_version": 0,
-            "values": {
-              "bypass_policy_lockout_safety_check": false,
-              "custom_key_store_id": null,
-              "customer_master_key_spec": "SYMMETRIC_DEFAULT",
-              "deletion_window_in_days": 10,
-              "description": "This key is used to encrypt bucket objects",
-              "enable_key_rotation": false,
-              "is_enabled": true,
-              "key_usage": "ENCRYPT_DECRYPT",
-              "tags": null
-            },
-            "sensitive_values": {
-              "tags_all": {}
-            }
-          },
           {
             "address": "aws_s3_bucket.mybucket",
             "mode": "managed",
@@ -125,588 +595,59 @@
           }
         ]
       }
-    },
-    "resource_drift": [
-      {
-        "address": "aws_s3_bucket.mybucket",
-        "mode": "managed",
-        "type": "aws_s3_bucket",
-        "name": "mybucket",
-        "provider_name": "registry.terraform.io/hashicorp/aws",
-        "change": {
-          "actions": [
-            "update"
-          ],
-          "before": {
-            "acceleration_status": "",
-            "acl": null,
-            "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-            "bucket": "nitish-s3-bucket-encryption",
-            "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-            "bucket_prefix": "",
-            "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-            "cors_rule": [],
-            "force_destroy": false,
-            "grant": [
-              {
-                "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-                "permissions": [
-                  "FULL_CONTROL"
-                ],
-                "type": "CanonicalUser",
-                "uri": ""
-              }
-            ],
-            "hosted_zone_id": "Z3BJ6K6RIION7M",
-            "id": "nitish-s3-bucket-encryption",
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-west-2",
-            "replication_configuration": [],
-            "request_payer": "BucketOwner",
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {
-                        "kms_master_key_id": "",
-                        "sse_algorithm": "AES256"
-                      }
-                    ],
-                    "bucket_key_enabled": false
-                  }
-                ]
-              }
-            ],
-            "tags": null,
-            "tags_all": {},
-            "timeouts": null,
-            "versioning": [
-              {
-                "enabled": false,
-                "mfa_delete": false
-              }
-            ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
-          },
-          "after": {
-            "acceleration_status": "",
-            "acl": null,
-            "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-            "bucket": "nitish-s3-bucket-encryption",
-            "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-            "bucket_prefix": "",
-            "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-            "cors_rule": [],
-            "force_destroy": false,
-            "grant": [
-              {
-                "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-                "permissions": [
-                  "FULL_CONTROL"
-                ],
-                "type": "CanonicalUser",
-                "uri": ""
-              }
-            ],
-            "hosted_zone_id": "Z3BJ6K6RIION7M",
-            "id": "nitish-s3-bucket-encryption",
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-west-2",
-            "replication_configuration": [],
-            "request_payer": "BucketOwner",
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {
-                        "kms_master_key_id": "",
-                        "sse_algorithm": "AES256"
-                      }
-                    ],
-                    "bucket_key_enabled": false
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "timeouts": null,
-            "versioning": [
-              {
-                "enabled": false,
-                "mfa_delete": false
-              }
-            ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
-          },
-          "after_unknown": {},
-          "before_sensitive": {
-            "cors_rule": [],
-            "grant": [
-              {
-                "permissions": [
-                  false
-                ]
-              }
-            ],
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "replication_configuration": [],
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {}
-                    ]
-                  }
-                ]
-              }
-            ],
-            "tags_all": {},
-            "versioning": [
-              {}
-            ],
-            "website": []
-          },
-          "after_sensitive": {
-            "cors_rule": [],
-            "grant": [
-              {
-                "permissions": [
-                  false
-                ]
-              }
-            ],
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "replication_configuration": [],
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {}
-                    ]
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "versioning": [
-              {}
-            ],
-            "website": []
-          }
-        }
-      }
-    ],
-    "resource_changes": [
-      {
-        "address": "aws_kms_key.mykey",
-        "mode": "managed",
-        "type": "aws_kms_key",
-        "name": "mykey",
-        "provider_name": "registry.terraform.io/hashicorp/aws",
-        "change": {
-          "actions": [
-            "create"
-          ],
-          "before": null,
-          "after": {
-            "bypass_policy_lockout_safety_check": false,
-            "custom_key_store_id": null,
-            "customer_master_key_spec": "SYMMETRIC_DEFAULT",
-            "deletion_window_in_days": 10,
-            "description": "This key is used to encrypt bucket objects",
-            "enable_key_rotation": false,
-            "is_enabled": true,
-            "key_usage": "ENCRYPT_DECRYPT",
-            "tags": null
-          },
-          "after_unknown": {
-            "arn": true,
-            "id": true,
-            "key_id": true,
-            "multi_region": true,
-            "policy": true,
-            "tags_all": true
-          },
-          "before_sensitive": false,
-          "after_sensitive": {
-            "tags_all": {}
-          }
-        }
-      },
-      {
-        "address": "aws_s3_bucket.mybucket",
-        "mode": "managed",
-        "type": "aws_s3_bucket",
-        "name": "mybucket",
-        "provider_name": "registry.terraform.io/hashicorp/aws",
-        "change": {
-          "actions": [
-            "no-op"
-          ],
-          "before": {
-            "acceleration_status": "",
-            "acl": null,
-            "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-            "bucket": "nitish-s3-bucket-encryption",
-            "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-            "bucket_prefix": "",
-            "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-            "cors_rule": [],
-            "force_destroy": false,
-            "grant": [
-              {
-                "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-                "permissions": [
-                  "FULL_CONTROL"
-                ],
-                "type": "CanonicalUser",
-                "uri": ""
-              }
-            ],
-            "hosted_zone_id": "Z3BJ6K6RIION7M",
-            "id": "nitish-s3-bucket-encryption",
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-west-2",
-            "replication_configuration": [],
-            "request_payer": "BucketOwner",
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {
-                        "kms_master_key_id": "",
-                        "sse_algorithm": "AES256"
-                      }
-                    ],
-                    "bucket_key_enabled": false
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "timeouts": null,
-            "versioning": [
-              {
-                "enabled": false,
-                "mfa_delete": false
-              }
-            ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
-          },
-          "after": {
-            "acceleration_status": "",
-            "acl": null,
-            "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-            "bucket": "nitish-s3-bucket-encryption",
-            "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-            "bucket_prefix": "",
-            "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-            "cors_rule": [],
-            "force_destroy": false,
-            "grant": [
-              {
-                "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-                "permissions": [
-                  "FULL_CONTROL"
-                ],
-                "type": "CanonicalUser",
-                "uri": ""
-              }
-            ],
-            "hosted_zone_id": "Z3BJ6K6RIION7M",
-            "id": "nitish-s3-bucket-encryption",
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "object_lock_enabled": false,
-            "policy": "",
-            "region": "us-west-2",
-            "replication_configuration": [],
-            "request_payer": "BucketOwner",
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {
-                        "kms_master_key_id": "",
-                        "sse_algorithm": "AES256"
-                      }
-                    ],
-                    "bucket_key_enabled": false
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "timeouts": null,
-            "versioning": [
-              {
-                "enabled": false,
-                "mfa_delete": false
-              }
-            ],
-            "website": [],
-            "website_domain": null,
-            "website_endpoint": null
-          },
-          "after_unknown": {},
-          "before_sensitive": {
-            "cors_rule": [],
-            "grant": [
-              {
-                "permissions": [
-                  false
-                ]
-              }
-            ],
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "replication_configuration": [],
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {}
-                    ]
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "versioning": [
-              {}
-            ],
-            "website": []
-          },
-          "after_sensitive": {
-            "cors_rule": [],
-            "grant": [
-              {
-                "permissions": [
-                  false
-                ]
-              }
-            ],
-            "lifecycle_rule": [],
-            "logging": [],
-            "object_lock_configuration": [],
-            "replication_configuration": [],
-            "server_side_encryption_configuration": [
-              {
-                "rule": [
-                  {
-                    "apply_server_side_encryption_by_default": [
-                      {}
-                    ]
-                  }
-                ]
-              }
-            ],
-            "tags": {},
-            "tags_all": {},
-            "versioning": [
-              {}
-            ],
-            "website": []
-          }
-        }
-      }
-    ],
-    "prior_state": {
-      "format_version": "1.0",
-      "terraform_version": "1.6.6",
-      "values": {
-        "root_module": {
-          "resources": [
-            {
-              "address": "aws_s3_bucket.mybucket",
-              "mode": "managed",
-              "type": "aws_s3_bucket",
-              "name": "mybucket",
-              "provider_name": "registry.terraform.io/hashicorp/aws",
-              "schema_version": 0,
-              "values": {
-                "acceleration_status": "",
-                "acl": null,
-                "arn": "arn:aws:s3:::nitish-s3-bucket-encryption",
-                "bucket": "nitish-s3-bucket-encryption",
-                "bucket_domain_name": "nitish-s3-bucket-encryption.s3.amazonaws.com",
-                "bucket_prefix": "",
-                "bucket_regional_domain_name": "nitish-s3-bucket-encryption.s3.us-west-2.amazonaws.com",
-                "cors_rule": [],
-                "force_destroy": false,
-                "grant": [
-                  {
-                    "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-                    "permissions": [
-                      "FULL_CONTROL"
-                    ],
-                    "type": "CanonicalUser",
-                    "uri": ""
-                  }
-                ],
-                "hosted_zone_id": "Z3BJ6K6RIION7M",
-                "id": "nitish-s3-bucket-encryption",
-                "lifecycle_rule": [],
-                "logging": [],
-                "object_lock_configuration": [],
-                "object_lock_enabled": false,
-                "policy": "",
-                "region": "us-west-2",
-                "replication_configuration": [],
-                "request_payer": "BucketOwner",
-                "server_side_encryption_configuration": [
-                  {
-                    "rule": [
-                      {
-                        "apply_server_side_encryption_by_default": [
-                          {
-                            "kms_master_key_id": "",
-                            "sse_algorithm": "AES256"
-                          }
-                        ],
-                        "bucket_key_enabled": false
-                      }
-                    ]
-                  }
-                ],
-                "tags": {},
-                "tags_all": {},
-                "timeouts": null,
-                "versioning": [
-                  {
-                    "enabled": false,
-                    "mfa_delete": false
-                  }
-                ],
-                "website": [],
-                "website_domain": null,
-                "website_endpoint": null
-              },
-              "sensitive_values": {
-                "cors_rule": [],
-                "grant": [
-                  {
-                    "permissions": [
-                      false
-                    ]
-                  }
-                ],
-                "lifecycle_rule": [],
-                "logging": [],
-                "object_lock_configuration": [],
-                "replication_configuration": [],
-                "server_side_encryption_configuration": [
-                  {
-                    "rule": [
-                      {
-                        "apply_server_side_encryption_by_default": [
-                          {}
-                        ]
-                      }
-                    ]
-                  }
-                ],
-                "tags": {},
-                "tags_all": {},
-                "versioning": [
-                  {}
-                ],
-                "website": []
-              }
-            }
-          ]
-        }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "version_constraint": "~> 4.16",
+        "expressions": {}
       }
     },
-    "configuration": {
-      "provider_config": {
-        "aws": {
-          "name": "aws",
-          "full_name": "registry.terraform.io/hashicorp/aws",
-          "version_constraint": "~> 4.16",
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_kms_key.mykey",
+          "mode": "managed",
+          "type": "aws_kms_key",
+          "name": "mykey",
+          "provider_config_key": "aws",
           "expressions": {
-          }
-        }
-      },
-      "root_module": {
-        "resources": [
-          {
-            "address": "aws_kms_key.mykey",
-            "mode": "managed",
-            "type": "aws_kms_key",
-            "name": "mykey",
-            "provider_config_key": "aws",
-            "expressions": {
-              "deletion_window_in_days": {
-                "constant_value": 10
-              },
-              "description": {
-                "constant_value": "This key is used to encrypt bucket objects"
-              }
+            "deletion_window_in_days": {
+              "constant_value": 10
             },
-            "schema_version": 0
+            "description": {
+              "constant_value": "This key is used to encrypt bucket objects"
+            }
           },
-          {
-            "address": "aws_s3_bucket.mybucket",
-            "mode": "managed",
-            "type": "aws_s3_bucket",
-            "name": "mybucket",
-            "provider_config_key": "aws",
-            "expressions": {
-              "bucket": {
-                "constant_value": "nitish-s3-bucket-encryption"
-              }
-            },
-            "schema_version": 0
-          }
-        ]
-      }
-    },
-    "relevant_attributes": [
-      {
-        "resource": "aws_s3_bucket.mybucket",
-        "attribute": [
-          "id"
-        ]
-      }
-    ],
-    "timestamp": "2024-01-18T19:12:30Z",
-    "errored": false
-  }
-  
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket.mybucket",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "mybucket",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "constant_value": "nitish-s3-bucket-encryption"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "aws_s3_bucket.mybucket",
+      "attribute": [
+        "id"
+      ]
+    }
+  ],
+  "timestamp": "2024-01-18T19:12:30Z",
+  "errored": false
+}

--- a/terraform/plan/s3-best-practices/enable-lifecycle-configuration/enable-lifecycle-configuration.yaml
+++ b/terraform/plan/s3-best-practices/enable-lifecycle-configuration/enable-lifecycle-configuration.yaml
@@ -25,20 +25,31 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-lifecycle
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_lifecycle_configuration')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: lifecycle_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_lifecycle_configuration')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
-    - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_lifecycle_configuration')
+    - expression: "variables.lifecycle_resources.size() >= variables.s3_buckets.size()"
       message: "Use the 'aws_s3_bucket_lifecycle_configuration' resource to enable lifecycle configuration."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_lifecycle_configuration').all(config,
-          has(config.values.rule) && 
-          config.values.rule != null &&
-          config.values.rule.exists(rule, 
-            has(rule.status) && rule.status == 'Enabled'
-          )
-        )
-      message: "S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'"
-
+        variables.lifecycle_resources.all(lc,
+          lc.change.after.rule.orValue([]).exists(rule,
+            rule.status == 'Enabled'))
+      message: "S3 Bucket Lifecycle Configuration 'status' needs to be set to 'Enabled'."

--- a/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/s3-cross-region-replication.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/s3-cross-region-replication.yaml
@@ -28,20 +28,31 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-replication
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_replication_configuration')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: replication_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_replication_configuration')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
+    - expression: "variables.replication_resources.size() > 0"
+      message: "Use the 'aws_s3_bucket_replication_configuration' resource to set the status to Enabled."
     - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_replication_configuration')
-      message: "Use the 'aws_s3_bucket_replication_configuration' resource to set the status to Enabled"
-    - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_replication_configuration').all(replication,
-          has(replication.values.rule) && 
-          replication.values.rule != null &&
-          replication.values.rule.exists(rule, 
-            has(rule.status) && rule.status == 'Enabled'
-          )
-        )
-      message: "Set S3 Bucket Cross Region Replication status to 'Enabled'"
-                   
+        variables.replication_resources.all(rep,
+          rep.change.after.rule.orValue([]).exists(rule,
+            rule.status == 'Enabled'))
+      message: "Set S3 Bucket Cross Region Replication status to 'Enabled'."

--- a/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/test/good-payload.json
+++ b/terraform/plan/s3-best-practices/enable-s3-cross-region-replication/test/good-payload.json
@@ -649,20 +649,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "arn": "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345",
-          "description": "",
-          "id": "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345",
-          "name": "tf-iam-role-policy-replication-12345",
-          "name_prefix": "",
-          "path": "/",
-          "policy": "{\"Statement\":[{\"Action\":[\"s3:ListBucket\",\"s3:GetReplicationConfiguration\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::tf-test-bucket-source-nitish-12345\"},{\"Action\":[\"s3:GetObjectVersionTagging\",\"s3:GetObjectVersionForReplication\",\"s3:GetObjectVersionAcl\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::tf-test-bucket-source-nitish-12345/*\"},{\"Action\":[\"s3:ReplicateTags\",\"s3:ReplicateObject\"],\"Effect\":\"Allow\",\"Resource\":\"arn:aws:s3:::tf-test-bucket-destination-nitish-12345/*\"}],\"Version\":\"2012-10-17\"}",
-          "policy_id": "ANPA4JFRUINQLTD64575W",
-          "tags": {},
-          "tags_all": {}
-        },
+        "before": null,
         "after": {
           "arn": "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345",
           "description": "",
@@ -694,28 +683,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "arn": "arn:aws:iam::844333597536:role/tf-iam-role-replication-12345",
-          "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"s3.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
-          "create_date": "2024-01-24T10:55:42Z",
-          "description": "",
-          "force_detach_policies": false,
-          "id": "tf-iam-role-replication-12345",
-          "inline_policy": [],
-          "managed_policy_arns": [
-            "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345"
-          ],
-          "max_session_duration": 3600,
-          "name": "tf-iam-role-replication-12345",
-          "name_prefix": "",
-          "path": "/",
-          "permissions_boundary": "",
-          "tags": {},
-          "tags_all": {},
-          "unique_id": "AROA4JFRUINQIGIEP43IO"
-        },
+        "before": null,
         "after": {
           "arn": "arn:aws:iam::844333597536:role/tf-iam-role-replication-12345",
           "assume_role_policy": "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"s3.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
@@ -763,13 +733,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "id": "tf-iam-role-replication-12345-20240124105702515800000001",
-          "policy_arn": "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345",
-          "role": "tf-iam-role-replication-12345"
-        },
+        "before": null,
         "after": {
           "id": "tf-iam-role-replication-12345-20240124105702515800000001",
           "policy_arn": "arn:aws:iam::844333597536:policy/tf-iam-role-policy-replication-12345",
@@ -788,66 +754,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "acceleration_status": "",
-          "acl": null,
-          "arn": "arn:aws:s3:::tf-test-bucket-destination-nitish-12345",
-          "bucket": "tf-test-bucket-destination-nitish-12345",
-          "bucket_domain_name": "tf-test-bucket-destination-nitish-12345.s3.amazonaws.com",
-          "bucket_prefix": "",
-          "bucket_regional_domain_name": "tf-test-bucket-destination-nitish-12345.s3.eu-west-1.amazonaws.com",
-          "cors_rule": [],
-          "force_destroy": false,
-          "grant": [
-            {
-              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-              "permissions": [
-                "FULL_CONTROL"
-              ],
-              "type": "CanonicalUser",
-              "uri": ""
-            }
-          ],
-          "hosted_zone_id": "Z1BKCTXD74EZPE",
-          "id": "tf-test-bucket-destination-nitish-12345",
-          "lifecycle_rule": [],
-          "logging": [],
-          "object_lock_configuration": [],
-          "object_lock_enabled": false,
-          "policy": "",
-          "region": "eu-west-1",
-          "replication_configuration": [],
-          "request_payer": "BucketOwner",
-          "server_side_encryption_configuration": [
-            {
-              "rule": [
-                {
-                  "apply_server_side_encryption_by_default": [
-                    {
-                      "kms_master_key_id": "",
-                      "sse_algorithm": "AES256"
-                    }
-                  ],
-                  "bucket_key_enabled": false
-                }
-              ]
-            }
-          ],
-          "tags": {},
-          "tags_all": {},
-          "timeouts": null,
-          "versioning": [
-            {
-              "enabled": true,
-              "mfa_delete": false
-            }
-          ],
-          "website": [],
-          "website_domain": null,
-          "website_endpoint": null
-        },
+        "before": null,
         "after": {
           "acceleration_status": "",
           "acl": null,
@@ -979,66 +888,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "acceleration_status": "",
-          "acl": null,
-          "arn": "arn:aws:s3:::tf-test-bucket-source-nitish-12345",
-          "bucket": "tf-test-bucket-source-nitish-12345",
-          "bucket_domain_name": "tf-test-bucket-source-nitish-12345.s3.amazonaws.com",
-          "bucket_prefix": "",
-          "bucket_regional_domain_name": "tf-test-bucket-source-nitish-12345.s3.eu-central-1.amazonaws.com",
-          "cors_rule": [],
-          "force_destroy": false,
-          "grant": [
-            {
-              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-              "permissions": [
-                "FULL_CONTROL"
-              ],
-              "type": "CanonicalUser",
-              "uri": ""
-            }
-          ],
-          "hosted_zone_id": "Z21DNDUVLTQW6Q",
-          "id": "tf-test-bucket-source-nitish-12345",
-          "lifecycle_rule": [],
-          "logging": [],
-          "object_lock_configuration": [],
-          "object_lock_enabled": false,
-          "policy": "",
-          "region": "eu-central-1",
-          "replication_configuration": [],
-          "request_payer": "BucketOwner",
-          "server_side_encryption_configuration": [
-            {
-              "rule": [
-                {
-                  "apply_server_side_encryption_by_default": [
-                    {
-                      "kms_master_key_id": "",
-                      "sse_algorithm": "AES256"
-                    }
-                  ],
-                  "bucket_key_enabled": false
-                }
-              ]
-            }
-          ],
-          "tags": {},
-          "tags_all": {},
-          "timeouts": null,
-          "versioning": [
-            {
-              "enabled": true,
-              "mfa_delete": false
-            }
-          ],
-          "website": [],
-          "website_domain": null,
-          "website_endpoint": null
-        },
+        "before": null,
         "after": {
           "acceleration_status": "",
           "acl": null,
@@ -1274,20 +1126,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "bucket": "tf-test-bucket-destination-nitish-12345",
-          "expected_bucket_owner": "",
-          "id": "tf-test-bucket-destination-nitish-12345",
-          "mfa": null,
-          "versioning_configuration": [
-            {
-              "mfa_delete": "",
-              "status": "Enabled"
-            }
-          ]
-        },
+        "before": null,
         "after": {
           "bucket": "tf-test-bucket-destination-nitish-12345",
           "expected_bucket_owner": "",
@@ -1321,20 +1162,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "bucket": "tf-test-bucket-source-nitish-12345",
-          "expected_bucket_owner": "",
-          "id": "tf-test-bucket-source-nitish-12345",
-          "mfa": null,
-          "versioning_configuration": [
-            {
-              "mfa_delete": "",
-              "status": "Enabled"
-            }
-          ]
-        },
+        "before": null,
         "after": {
           "bucket": "tf-test-bucket-source-nitish-12345",
           "expected_bucket_owner": "",
@@ -1889,15 +1719,13 @@
       "aws": {
         "name": "aws",
         "full_name": "registry.terraform.io/hashicorp/aws",
-        "expressions": {
-        }
+        "expressions": {}
       },
       "aws.central": {
         "name": "aws",
         "full_name": "registry.terraform.io/hashicorp/aws",
         "alias": "central",
-        "expressions": {
-        }
+        "expressions": {}
       }
     },
     "root_module": {

--- a/terraform/plan/s3-best-practices/enable-s3-server-access-logging/enable-server-access-logging.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-server-access-logging/enable-server-access-logging.yaml
@@ -28,11 +28,26 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-logging
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_logging')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: logging_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_logging')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
-    - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_logging')
-      message: "Use the aws_s3_bucket_logging resource to enable server access logging"
-                   
+    - expression: "variables.logging_resources.size() > 0"
+      message: "Use the aws_s3_bucket_logging resource to enable server access logging."

--- a/terraform/plan/s3-best-practices/enable-s3-versioning/s3-enable-versioning.yaml
+++ b/terraform/plan/s3-best-practices/enable-s3-versioning/s3-enable-versioning.yaml
@@ -7,10 +7,10 @@ metadata:
     policies.kyverno.io/category: AWS S3 Security Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      Versioning in Amazon S3 is a means of keeping multiple variants of an object 
+      Versioning in Amazon S3 is a means of keeping multiple variants of an object
       in the same bucket. You can use the S3 Versioning feature to preserve, retrieve,
-      and restore every version of every object stored in your buckets. With versioning 
-      you can recover more easily from both unintended user actions and application 
+      and restore every version of every object stored in your buckets. With versioning
+      you can recover more easily from both unintended user actions and application
       failures. After versioning is enabled for a bucket, if Amazon S3 receives multiple
       write requests for the same object simultaneously, it stores all of those objects.
 spec:
@@ -28,21 +28,31 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-versioning
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket' || rc.type == 'aws_s3_bucket_versioning')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: s3_versioning_resources
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_versioning')"
+    - name: s3_buckets
+      expression: |
+        variables.resource_changes.filter(rc,
+          rc.type == 'aws_s3_bucket'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
   validations:
+    - expression: "variables.s3_versioning_resources.size() >= variables.s3_buckets.size()"
+      message: "Use the 'aws_s3_bucket_versioning' resource to enable versioning for each S3 bucket."
     - expression: |
-        object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_versioning')
-      message: "Use the 'aws_s3_bucket_versioning' resource to enable versioning."
-    - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_versioning').all(versioning,
-          has(versioning.values.versioning_configuration) && 
-          versioning.values.versioning_configuration != null &&
-          versioning.values.versioning_configuration.exists(config, 
-            has(config.status) && config.status == 'Enabled'
-          )
-        )
-      message: "S3 Bucket Versioning needs to be set to 'Enabled'"
-            
-           
+        variables.s3_versioning_resources.all(rv,
+          rv.change.after.versioning_configuration.orValue([]).size() > 0
+          && rv.change.after.versioning_configuration[0].status == 'Enabled')
+      message: "S3 Bucket Versioning needs to be set to 'Enabled'."

--- a/terraform/plan/s3-best-practices/enable-s3-versioning/test/bad-payload-02.json
+++ b/terraform/plan/s3-best-practices/enable-s3-versioning/test/bad-payload-02.json
@@ -305,66 +305,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "acceleration_status": "",
-          "acl": null,
-          "arn": "arn:aws:s3:::test-bucket-demo-18012003",
-          "bucket": "test-bucket-demo-18012003",
-          "bucket_domain_name": "test-bucket-demo-18012003.s3.amazonaws.com",
-          "bucket_prefix": "",
-          "bucket_regional_domain_name": "test-bucket-demo-18012003.s3.us-west-2.amazonaws.com",
-          "cors_rule": [],
-          "force_destroy": false,
-          "grant": [
-            {
-              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-              "permissions": [
-                "FULL_CONTROL"
-              ],
-              "type": "CanonicalUser",
-              "uri": ""
-            }
-          ],
-          "hosted_zone_id": "Z3BJ6K6RIION7M",
-          "id": "test-bucket-demo-18012003",
-          "lifecycle_rule": [],
-          "logging": [],
-          "object_lock_configuration": [],
-          "object_lock_enabled": false,
-          "policy": "",
-          "region": "us-west-2",
-          "replication_configuration": [],
-          "request_payer": "BucketOwner",
-          "server_side_encryption_configuration": [
-            {
-              "rule": [
-                {
-                  "apply_server_side_encryption_by_default": [
-                    {
-                      "kms_master_key_id": "",
-                      "sse_algorithm": "AES256"
-                    }
-                  ],
-                  "bucket_key_enabled": false
-                }
-              ]
-            }
-          ],
-          "tags": {},
-          "tags_all": {},
-          "timeouts": null,
-          "versioning": [
-            {
-              "enabled": false,
-              "mfa_delete": false
-            }
-          ],
-          "website": [],
-          "website_domain": null,
-          "website_endpoint": null
-        },
+        "before": null,
         "after": {
           "acceleration_status": "",
           "acl": null,
@@ -602,8 +545,7 @@
         "name": "aws",
         "full_name": "registry.terraform.io/hashicorp/aws",
         "version_constraint": "~> 4.16",
-        "expressions": {
-        }
+        "expressions": {}
       }
     },
     "root_module": {

--- a/terraform/plan/s3-best-practices/enable-s3-versioning/test/good-payload.json
+++ b/terraform/plan/s3-best-practices/enable-s3-versioning/test/good-payload.json
@@ -328,66 +328,9 @@
       "provider_name": "registry.terraform.io/hashicorp/aws",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
-        "before": {
-          "acceleration_status": "",
-          "acl": null,
-          "arn": "arn:aws:s3:::test-bucket-demo-18012003",
-          "bucket": "test-bucket-demo-18012003",
-          "bucket_domain_name": "test-bucket-demo-18012003.s3.amazonaws.com",
-          "bucket_prefix": "",
-          "bucket_regional_domain_name": "test-bucket-demo-18012003.s3.us-west-2.amazonaws.com",
-          "cors_rule": [],
-          "force_destroy": false,
-          "grant": [
-            {
-              "id": "62ea66bd2e8f7e76e4fb466e942a41389d6057fcc90d732feaac373bb0d0a7a5",
-              "permissions": [
-                "FULL_CONTROL"
-              ],
-              "type": "CanonicalUser",
-              "uri": ""
-            }
-          ],
-          "hosted_zone_id": "Z3BJ6K6RIION7M",
-          "id": "test-bucket-demo-18012003",
-          "lifecycle_rule": [],
-          "logging": [],
-          "object_lock_configuration": [],
-          "object_lock_enabled": false,
-          "policy": "",
-          "region": "us-west-2",
-          "replication_configuration": [],
-          "request_payer": "BucketOwner",
-          "server_side_encryption_configuration": [
-            {
-              "rule": [
-                {
-                  "apply_server_side_encryption_by_default": [
-                    {
-                      "kms_master_key_id": "",
-                      "sse_algorithm": "AES256"
-                    }
-                  ],
-                  "bucket_key_enabled": false
-                }
-              ]
-            }
-          ],
-          "tags": {},
-          "tags_all": {},
-          "timeouts": null,
-          "versioning": [
-            {
-              "enabled": false,
-              "mfa_delete": false
-            }
-          ],
-          "website": [],
-          "website_domain": null,
-          "website_endpoint": null
-        },
+        "before": null,
         "after": {
           "acceleration_status": "",
           "acl": null,
@@ -662,8 +605,7 @@
         "name": "aws",
         "full_name": "registry.terraform.io/hashicorp/aws",
         "version_constraint": "~> 4.16",
-        "expressions": {
-        }
+        "expressions": {}
       }
     },
     "root_module": {

--- a/terraform/plan/s3-best-practices/public-access-block/validate-public-access-block.yaml
+++ b/terraform/plan/s3-best-practices/public-access-block/validate-public-access-block.yaml
@@ -7,11 +7,11 @@ metadata:
     policies.kyverno.io/category: AWS S3 Security Best Practices
     policies.kyverno.io/severity: medium
     policies.kyverno.io/description: >-
-      The Amazon S3 Block Public Access feature provides settings for access points, 
+      The Amazon S3 Block Public Access feature provides settings for access points,
       buckets, and accounts to help you manage public access to Amazon S3 resources.
       By default, new buckets, access points, and objects don't allow public access.
-      However, users can modify bucket policies, access point policies, or object 
-      permissions to allow public access. S3 Block Public Access settings override 
+      However, users can modify bucket policies, access point policies, or object
+      permissions to allow public access. S3 Block Public Access settings override
       these policies and permissions so that you can limit public access to these resources.
 spec:
   validationActions:
@@ -28,31 +28,35 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
-    - name: has-s3-bucket-public-access-block
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_public_access_block' || r.type == 'aws_s3_bucket')"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
+    - name: has-s3-bucket-or-public-access-block
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && (rc.type == 'aws_s3_bucket_public_access_block' || rc.type == 'aws_s3_bucket')
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.after != null)
+    - name: public_access_blocks
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_public_access_block')"
   validations:
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_public_access_block').all(block,
-          has(block.values.block_public_acls) && 
-          block.values.block_public_acls == true
-        )
-      message: "Block Public ACLs should be set to true"
+        variables.public_access_blocks.all(b,
+          b.change.after.block_public_acls.orValue(false) == true)
+      message: "Block Public ACLs should be set to true."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_public_access_block').all(block,
-          has(block.values.block_public_policy) && 
-          block.values.block_public_policy == true
-        )
-      message: "Block Public Policy should be set to true"
+        variables.public_access_blocks.all(b,
+          b.change.after.block_public_policy.orValue(false) == true)
+      message: "Block Public Policy should be set to true."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_public_access_block').all(block,
-          has(block.values.ignore_public_acls) && 
-          block.values.ignore_public_acls == true
-        )
-      message: "Ignore Public ACLs should be set to true"
+        variables.public_access_blocks.all(b,
+          b.change.after.ignore_public_acls.orValue(false) == true)
+      message: "Ignore Public ACLs should be set to true."
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_public_access_block').all(block,
-          has(block.values.restrict_public_buckets) && 
-          block.values.restrict_public_buckets == true
-        )
-      message: "Restrict Public Buckets should be set to true"
+        variables.public_access_blocks.all(b,
+          b.change.after.restrict_public_buckets.orValue(false) == true)
+      message: "Restrict Public Buckets should be set to true."

--- a/terraform/plan/s3-best-practices/validate-any-prinicpal/validate-any-principal.yaml
+++ b/terraform/plan/s3-best-practices/validate-any-prinicpal/validate-any-principal.yaml
@@ -10,7 +10,7 @@ metadata:
      Principal value in an IAM policy specifies which user or entity
      is allowed or denied access to a resource. For policies attached
      to an S3 bucket, this policy validates if the Principal allowed is
-     `*`, which means ANY Principal is allowed access to the resource.
+     '*', which means ANY Principal is allowed access to the resource.
 spec:
   validationActions:
     - Deny
@@ -26,17 +26,26 @@ spec:
         operations: ["CREATE", "UPDATE"]
   matchConditions:
     - name: is-terraform-plan
-      expression: "has(object.planned_values) && has(object.terraform_version)"
+      expression: "has(object.resource_changes) && has(object.terraform_version)"
     - name: has-s3-bucket-policy
-      expression: "has(object.planned_values) && has(object.planned_values.root_module) && has(object.planned_values.root_module.resources) && object.planned_values.root_module.resources.exists(r, r.type == 'aws_s3_bucket_policy')"
+      expression: |
+        object.resource_changes.exists(rc,
+          rc.mode == 'managed'
+          && rc.type == 'aws_s3_bucket_policy'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+  variables:
+    - name: resource_changes
+      expression: |
+        object.resource_changes.filter(rc,
+          rc.mode == 'managed'
+          && rc.change.actions.exists(a, a == 'create' || a == 'update'))
+    - name: bucket_policies
+      expression: "variables.resource_changes.filter(rc, rc.type == 'aws_s3_bucket_policy')"
   validations:
     - expression: |
-        object.planned_values.root_module.resources.filter(r, r.type == 'aws_s3_bucket_policy').all(policy,
-          has(policy.values.policy) && 
-          policy.values.policy != null &&
-          !(policy.values.policy.contains('"Principal":"*"') || 
-            policy.values.policy.contains('"Principal": "*"') ||
-            policy.values.policy.contains('"AWS":"*"') ||
-            policy.values.policy.contains('"AWS": "*"'))
-        )
+        variables.bucket_policies.all(bp,
+          !(bp.change.after.policy.orValue('').contains('"Principal":"*"') ||
+            bp.change.after.policy.orValue('').contains('"Principal": "*"') ||
+            bp.change.after.policy.orValue('').contains('"AWS":"*"') ||
+            bp.change.after.policy.orValue('').contains('"AWS": "*"')))
       message: "Principal should not be set to '*' in the Bucket Policy."


### PR DESCRIPTION
- Replace planned_values with resource_changes in matchConditions
- Add variables to filter managed create/update resources
- Update validations to check change.after instead of planned_values
- Fix bad-payload-02: set action to 'create' and before to null
- Fixes #238



